### PR TITLE
🧪 Add test for database connection failure

### DIFF
--- a/apps/inc/db.php
+++ b/apps/inc/db.php
@@ -23,10 +23,10 @@ See the MIT License for more details
 
 copyright (c) 2015-2021 by cahya dsn; cahyadsn@gmail.com
 ================================================================================*/
-$dbhost='localhost';
-$dbuser='root';
-$dbpass='';
-$dbname='wilayah';
+$dbhost = getenv('DB_HOST') !== false ? getenv('DB_HOST') : 'localhost';
+$dbuser = getenv('DB_USER') !== false ? getenv('DB_USER') : 'root';
+$dbpass = getenv('DB_PASS') !== false ? getenv('DB_PASS') : '';
+$dbname = getenv('DB_NAME') !== false ? getenv('DB_NAME') : 'wilayah';
 $db_dsn = "mysql:dbname=$dbname;host=$dbhost";
 $tbl_wilayah="wilayah_level_1_2";
 try {

--- a/tests/test_db_connection.php
+++ b/tests/test_db_connection.php
@@ -1,0 +1,26 @@
+<?php
+// Test for database connection failure handling in db.php
+
+$original_file = __DIR__ . '/../apps/inc/db.php';
+
+// Set environment variables to force a connection failure
+putenv('DB_USER=invalid_test_user');
+putenv('DB_PASS=invalid_test_pass');
+
+// Capture output
+ob_start();
+include $original_file;
+$output = ob_get_clean();
+
+// Reset environment variables
+putenv('DB_USER');
+putenv('DB_PASS');
+
+// Assert
+if (strpos($output, 'Connection failed:') !== false) {
+    echo "PASS: Database connection failure caught and handled correctly.\n";
+    exit(0);
+} else {
+    echo "FAIL: Expected error message not found. Output was: \n" . $output . "\n";
+    exit(1);
+}


### PR DESCRIPTION
🎯 **What:** The database connection in `apps/inc/db.php` lacked testing for its `PDOException` `catch` block handling.
📊 **Coverage:** A test is added in `tests/test_db_connection.php` to capture and assert the error message on invalid DB credentials.
✨ **Result:** Increased testing coverage around the database connection, resolving the gap in connection failure testing. Refactored hard-coded database configuration to optionally leverage environment variables for testing purposes.

---
*PR created automatically by Jules for task [8763244528998917187](https://jules.google.com/task/8763244528998917187) started by @cahyadsn*