### PR TITLE
🔒 Fix hardcoded database credentials in db.php and index.php

### DIFF
--- a/apps/inc/db.php
+++ b/apps/inc/db.php
@@ -23,10 +23,10 @@ See the MIT License for more details
 
 copyright (c) 2015-2021 by cahya dsn; cahyadsn@gmail.com
 ================================================================================*/
-$dbhost='localhost';
-$dbuser='root';
-$dbpass='';
-$dbname='wilayah';
+$dbhost = getenv('DB_HOST') ?: 'localhost';
+$dbuser = getenv('DB_USER') ?: 'root';
+$dbpass = getenv('DB_PASS') ?: '';
+$dbname = getenv('DB_NAME') ?: 'wilayah';
 $db_dsn = "mysql:dbname=$dbname;host=$dbhost";
 $tbl_wilayah="wilayah_level_1_2";
 try {

--- a/index.php
+++ b/index.php
@@ -26,10 +26,10 @@ See the MIT License for more details
 copyright (c) 2017-2022 by cahya dsn; cahyadsn@gmail.com
 ================================================================================*/
 //--- Database configuration
-$dbhost ='localhost';
-$dbuser ='root';
-$dbpass ='';
-$dbname ='wilayah';
+$dbhost = getenv('DB_HOST') ?: 'localhost';
+$dbuser = getenv('DB_USER') ?: 'root';
+$dbpass = getenv('DB_PASS') ?: '';
+$dbname = getenv('DB_NAME') ?: 'wilayah';
 $dbdsn = "mysql:dbname={$dbname};host={$dbhost}";
 try {
   $db = new PDO($dbdsn, $dbuser, $dbpass);


### PR DESCRIPTION
🎯 **What:** Hardcoded database connection credentials were found in `apps/inc/db.php` and `index.php`. They were updated to utilize `getenv()` to retrieve variables, falling back to localhost defaults if missing.
⚠️ **Risk:** Hardcoded credentials could be exposed through repository access, accidental file exposures, or source code disclosure, leading to unauthorized database access.
🛡️ **Solution:** Moved configuration values to `getenv('DB_HOST')`, `getenv('DB_USER')`, etc. Default fallbacks ensure local execution remains uninterrupted.

---
*PR created automatically by Jules for task [640104285522528095](https://jules.google.com/task/640104285522528095) started by @cahyadsn*