### PR TITLE
🧹 Refactor DB connection inclusions to use require_once

### DIFF
--- a/apps/inc/geo_ajax.php
+++ b/apps/inc/geo_ajax.php
@@ -27,7 +27,7 @@ See the MIT License for more details
 
 copyright (c) 2017-2024 by cahya dsn; cahyadsn@gmail.com
 ================================================================================*/
-include "db.php";
+require_once "db.php";
 $r=array('status'=>false,'error'=>'an error occured');
 if (!empty($_GET['id'])){
   $query = $db->prepare("SELECT * FROM {$tbl_wilayah} WHERE kode=:id");

--- a/apps/inc/geo_update.php
+++ b/apps/inc/geo_update.php
@@ -28,7 +28,7 @@ if (!isset($_SESSION['author']) || $_SESSION['author'] !== 'cahyadsn') {
     die(json_encode(array('status' => false, 'msg' => 'unauthorized')));
 }
 
-include "db.php";
+require_once "db.php";
 $r=array('status'=>false,'msg'=>'do nothing');
 $fields=array('lat','lng','path');
 if(isset($_POST['id'])){

--- a/apps/index.php
+++ b/apps/index.php
@@ -30,7 +30,7 @@ $c=isset($_SESSION['c'])?$_SESSION['c']:(isset($_GET['c'])?$_GET['c']:'indigo');
 define("_AUTHOR","cahyadsn");
 $_SESSION['author']='cahyadsn';
 $_SESSION['ver']=sha1(rand());
-include 'inc/db.php';
+require_once 'inc/db.php';
 $version='2.8';
 header('Expires: '.date('r'));
 header('Cache-Control: no-store, no-cache, must-revalidate');


### PR DESCRIPTION
🎯 **What:** Replaced `include "db.php"` and `include 'inc/db.php'` with `require_once "db.php"` and `require_once 'inc/db.php'` respectively in `apps/inc/geo_ajax.php`, `apps/inc/geo_update.php`, and `apps/index.php`.
💡 **Why:** Using `require_once` prevents multiple inclusions of the database configuration and stops redundant instantiations of the PDO database connection. It will also ensure the application halts if the database configuration script cannot be loaded.
✅ **Verification:** Verified the code using PHP syntax linter (`php -l`) and ran the test script `tests/test_db_connection.php`.
✨ **Result:** Enhanced the maintainability and correctness of the codebase without changing external behavior.

---
*PR created automatically by Jules for task [1887498379734976988](https://jules.google.com/task/1887498379734976988) started by @cahyadsn*