### PR TITLE
🧪 Add unit tests for reverse lookup geometric functions

### DIFF
--- a/tests/inc/ReverseLookupTest.php
+++ b/tests/inc/ReverseLookupTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class ReverseLookupTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        // To safely include apps/inc/reverse_lookup.php which executes procedural code,
+        // we need to mock the environment to prevent it from exiting early.
+
+        // Mock a PDO connection for db.php inclusion if it's not already set
+        if (!isset($GLOBALS['db'])) {
+            $pdoMock = new class extends PDO {
+                public function __construct() {}
+                #[\ReturnTypeWillChange]
+                public function prepare($query, $options = []) {
+                    return new class {
+                        public function execute($params = null) { return true; }
+                        public function fetchAll($mode = null, ...$args) {
+                            return [['kode' => '11', 'nama' => 'Aceh', 'lat' => 0, 'lng' => 0]];
+                        }
+                        public function fetch($mode = null, $cursorOrientation = null, $cursorOffset = null) {
+                            return false;
+                        }
+                    };
+                }
+            };
+            $GLOBALS['db'] = $pdoMock;
+        }
+
+        // Set GET variables to prevent exit on missing coordinates
+        $_GET['lat'] = 0;
+        $_GET['lng'] = 0;
+
+        // Capture any output like headers or JSON
+        ob_start();
+
+        // Expose $db to the global scope since reverse_lookup.php expects it from db.php (which we bypass or supplement)
+        global $db;
+        $db = $GLOBALS['db'];
+
+        // Using @ to suppress "headers already sent" warnings
+        @require_once __DIR__ . '/../../apps/inc/reverse_lookup.php';
+
+        ob_end_clean();
+    }
+
+    public function testPointInRing(): void
+    {
+        $ring = [
+            [0, 0],
+            [0, 10],
+            [10, 10],
+            [10, 0]
+        ];
+
+        // Point inside
+        $this->assertTrue(pointInRing(5, 5, $ring));
+
+        // Point outside
+        $this->assertFalse(pointInRing(15, 15, $ring));
+        $this->assertFalse(pointInRing(-5, 5, $ring));
+
+        // Invalid ring (< 3 points)
+        $this->assertFalse(pointInRing(5, 5, [[0, 0], [0, 10]]));
+    }
+
+    public function testPointInPath(): void
+    {
+        // Simple 1-ring path JSON
+        $singleRingJson = json_encode([
+            [
+                [0, 0], [0, 10], [10, 10], [10, 0]
+            ]
+        ]);
+
+        $this->assertTrue(pointInPath(5, 5, $singleRingJson));
+        $this->assertFalse(pointInPath(15, 15, $singleRingJson));
+
+        // Multi-ring path JSON (e.g. islands)
+        $multiRingJson = json_encode([
+            [
+                [0, 0], [0, 10], [10, 10], [10, 0]
+            ],
+            [
+                [20, 20], [20, 30], [30, 30], [30, 20]
+            ]
+        ]);
+
+        $this->assertTrue(pointInPath(5, 5, $multiRingJson));
+        $this->assertTrue(pointInPath(25, 25, $multiRingJson));
+        $this->assertFalse(pointInPath(15, 15, $multiRingJson));
+
+        // Empty or invalid inputs
+        $this->assertFalse(pointInPath(5, 5, ''));
+        $this->assertFalse(pointInPath(5, 5, 'not-json'));
+        $this->assertFalse(pointInPath(5, 5, '[]'));
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added unit tests for the pure geometric functions `pointInRing` and `pointInPath` inside `apps/inc/reverse_lookup.php`. Since the file contains procedural execution logic, the tests mock the execution environment (mock PDO object and GET parameters) to safely include the script and access the functions without triggering runtime errors.

📊 **Coverage:** Covered happy paths (points inside), negative paths (points outside), and edge cases (invalid shapes, invalid JSON, empty inputs) for the polygon intersection algorithms.

✨ **Result:** Improved test coverage for geometric coordinate calculations in the reverse lookup implementation.

---
*PR created automatically by Jules for task [8544662255013020794](https://jules.google.com/task/8544662255013020794) started by @cahyadsn*