### PR TITLE
🎨 Palette: Improve region selector keyboard navigation and loading a11y

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,1 +1,7 @@
-## 2026-05-15 - Improve form labels and icon-only theme buttons accessibility\n**Learning:** The legacy PHP view had several form labels unassociated with inputs, which reduces click targets and accessibility. Icon-only link elements used for the theme switcher were completely hidden from screen readers. These are common patterns in older HTML that benefit from targeted a11y attributes.\n**Action:** Always check form labels for `for` associations and icon-only buttons/links for `aria-label` and `title` tooltips to provide context.
+## 2024-05-20 - Auto-focusing dynamically revealed inputs
+**Learning:** Moving focus to newly populated dropdowns significantly improves keyboard navigation flow in multi-step forms, saving users from manually tabbing to the next input.
+**Action:** Always consider auto-focusing the next logical input field when an action (like a selection) causes it to appear or populate, provided it doesn't disrupt the user's expected flow.
+
+## 2024-05-20 - ARIA Live regions for AJAX loading
+**Learning:** Loading spinners alone are insufficient for screen reader users. Dynamic content updates need ARIA live regions to announce state changes.
+**Action:** Consistently use `role="status"` and `aria-live="polite"` on containers that hold loading indicators or dynamic status text to ensure screen readers announce them.

--- a/apps/inc/geo_js.php
+++ b/apps/inc/geo_js.php
@@ -427,14 +427,6 @@ function stateChanged() {
             return;
         }
 
-        // Update the appropriate dropdown
-        if (idx > 0) {
-            var sel = document.getElementById(wil[idx]);
-            if (sel && d.opt) {
-                sel.innerHTML = d.opt;
-            }
-        }
-
         // Cascade visibility: show target, hide deeper levels, reset them
         if (n == 2) {
             document.getElementById("kab_box").style.display = 'block';
@@ -448,6 +440,15 @@ function stateChanged() {
             document.getElementById("kel").innerHTML = "<option value=''>Pilih Desa</option>";
         } else if (n == 8) {
             document.getElementById("kel_box").style.display = 'block';
+        }
+
+        // Update the appropriate dropdown and focus it
+        if (idx > 0) {
+            var sel = document.getElementById(wil[idx]);
+            if (sel && d.opt) {
+                sel.innerHTML = d.opt;
+                sel.focus();
+            }
         }
 
         // Update info strip

--- a/apps/index.php
+++ b/apps/index.php
@@ -115,7 +115,7 @@ header('Pragma: cache');
 
             <div class="card-body">
               <!-- Preload indicator -->
-              <div id="preload">
+              <div id="preload" role="status" aria-live="polite">
                 <div class="spinner"></div>
                 <span>Loading...</span>
               </div>


### PR DESCRIPTION
This PR adds a couple of minor UX and accessibility improvements to the region selector:

1. **Auto-focus on cascade:** When a user selects a region (e.g., Province), the next level dropdown (e.g., City) is automatically focused once it's populated. This makes it much easier to navigate the form using only the keyboard.
2. **Screen reader support for loading state:** Added `role="status" aria-live="polite"` to the `#preload` loading indicator so that screen readers announce "Loading..." during AJAX requests.

---
*PR created automatically by Jules for task [2919011788358771715](https://jules.google.com/task/2919011788358771715) started by @cahyadsn*