### PR TITLE
🧹 Extract duplicate do_ajax() function to shared utility

### DIFF
--- a/apps/inc/geo_js.php
+++ b/apps/inc/geo_js.php
@@ -32,11 +32,6 @@ var ids, my_id, my_z;
 var wil = new Array('prov', 'kota', 'kec', 'kel');
 
 // --- AJAX helpers ---
-function do_ajax() {
-    if (window.XMLHttpRequest) return new XMLHttpRequest();
-    if (window.ActiveXObject) return new ActiveXObject("Microsoft.XMLHTTP");
-    return null;
-}
 
 var my_ajax = do_ajax();
 

--- a/apps/index.php
+++ b/apps/index.php
@@ -203,6 +203,7 @@ header('Pragma: cache');
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
     integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
   <script src="https://unpkg.com/leaflet-draw@0.4.13/dist/leaflet.draw.js" defer></script>
+  <script src="js/ajax.js" defer></script>
   <script src="inc/geo_js.php?v=<?php echo $version;?>" defer></script>
   <script src="js/wilayah.min.js?v=<?php echo $version;?>" defer></script>
 

--- a/apps/js/ajax.js
+++ b/apps/js/ajax.js
@@ -1,0 +1,8 @@
+/* ============================================================
+   Shared AJAX helper
+   ============================================================ */
+function do_ajax() {
+    if (window.XMLHttpRequest) return new XMLHttpRequest();
+    if (window.ActiveXObject) return new ActiveXObject("Microsoft.XMLHTTP");
+    return null;
+}

--- a/index.php
+++ b/index.php
@@ -51,6 +51,7 @@ if (isset($_GET['id']) && !empty($_GET['id'])){
 			td,select {width:240px;}
 			#kab_box,#kec_box,#kel_box{display:none;}
 		 </style>
+		<script src="apps/js/ajax.js"></script>
 		<script>
 		var my_ajax=do_ajax();
 		var ids;
@@ -63,11 +64,6 @@ if (isset($_GET['id']) && !empty($_GET['id'])){
 				my_ajax.open("GET",url,true);
 				my_ajax.send(null);
 			}
-		}
-		function do_ajax(){
-			if (window.XMLHttpRequest) return new XMLHttpRequest();
-			if (window.ActiveXObject) return new ActiveXObject("Microsoft.XMLHTTP");
-			return null;
 		}
 		function stateChanged(){
 			var n=ids.length;


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Extracted the duplicated standard AJAX initialization function (`do_ajax()`) from multiple locations (`index.php`, `apps/inc/geo_js.php`) into a new shared JavaScript utility file (`apps/js/ajax.js`).

💡 **Why:** How this improves maintainability
Extracting this simple and self-contained standard AJAX initialization into a shared JS utility file reduces duplication, maintains consistency, and creates a single source of truth for creating AJAX objects.

✅ **Verification:** How you confirmed the change is safe
- Verified the script inclusion order matches dependency requirements (e.g., `defer` used correctly in `apps/index.php`).
- Checked PHP syntax with `php -l`.
- Ran the test suite using `vendor/bin/phpunit` (any failures observed were pre-existing unrelated issues).
- Requested AI code review and received a `#Correct#` rating confirming safety and correctness.

✨ **Result:** The improvement achieved
A single shared `do_ajax()` implementation is now used across the codebase, eliminating code duplication and ensuring any future changes to AJAX initialization only need to be made in one place.

---
*PR created automatically by Jules for task [9389955687936755027](https://jules.google.com/task/9389955687936755027) started by @cahyadsn*