### PR TITLE
🧪 Add test for Reverse Lookup Throwable catch block

### DIFF
--- a/tests/apps/inc/ReverseLookupTest.php
+++ b/tests/apps/inc/ReverseLookupTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use PDO;
+use PDOException;
+
+class ReverseLookupTest extends TestCase
+{
+    private $dbFile = __DIR__ . '/../../../apps/inc/db.php';
+    private $reverseLookupFile = __DIR__ . '/../../../apps/inc/reverse_lookup.php';
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testThrowableCatchBlockReturnsJsonError()
+    {
+        $_GET['lat'] = '-6.200000';
+        $_GET['lng'] = '106.816666';
+
+        putenv('DB_HOST=invalid');
+
+        ob_start();
+        require_once $this->dbFile;
+        ob_get_clean();
+
+        $mockPdo = $this->createMock(PDO::class);
+        $mockPdo->method('prepare')
+            ->willThrowException(new PDOException('Mocked database failure'));
+
+        global $db;
+        $db = $mockPdo;
+
+        ob_start();
+
+        $cwd = getcwd();
+        chdir(dirname($this->reverseLookupFile));
+
+        include basename($this->reverseLookupFile);
+
+        chdir($cwd);
+
+        $output = ob_get_clean();
+
+        $this->assertJson($output);
+        $decoded = json_decode($output, true);
+
+        $this->assertArrayHasKey('status', $decoded);
+        $this->assertFalse($decoded['status']);
+        $this->assertArrayHasKey('error', $decoded);
+        $this->assertEquals('Mocked database failure', $decoded['error']);
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the lack of coverage for the `catch (Throwable $e)` block in `apps/inc/reverse_lookup.php`. It simulates a database failure and confirms that the script correctly processes the error instead of crashing.

📊 **Coverage:** What scenarios are now tested
The primary error scenario tested is a failure when preparing the database query, ensuring that it correctly returns a well-formed JSON object containing `{"status": false, "error": "<Exception Message>"}`.

✨ **Result:** The improvement in test coverage
Test coverage has increased by introducing a new, dedicated test file `tests/apps/inc/ReverseLookupTest.php` that properly mocks the environment for the target procedural PHP script and validates the JSON error payload structure.

---
*PR created automatically by Jules for task [11906700055222118936](https://jules.google.com/task/11906700055222118936) started by @cahyadsn*