### PR TITLE
🔒 Fix information exposure in database connection error

### DIFF
--- a/apps/inc/db.php
+++ b/apps/inc/db.php
@@ -32,5 +32,6 @@ $tbl_wilayah="wilayah_level_1_2";
 try {
   $db = new PDO($db_dsn, $dbuser, $dbpass);
 } catch (PDOException $e) {
-  echo 'Connection failed: '.$e->getMessage();
+  error_log('Connection failed: ' . $e->getMessage());
+  echo 'Connection failed: Database error occurred.';
 }


### PR DESCRIPTION
🎯 **What:** Fixed an Information Exposure vulnerability in `apps/inc/db.php` where a PDO database connection exception message was directly echoed to the end user.
⚠️ **Risk:** Directly echoing `$e->getMessage()` from a PDOException can expose sensitive information like the DSN, database username, or hostname to potential attackers.
🛡️ **Solution:** Replaced the direct echo with `error_log()` to log the detailed exception securely to the server, and updated the output to display a generic fallback message `Connection failed: Database error occurred.`. This ensures that database connections fail safely without revealing sensitive backend infrastructure details to users, and continues to satisfy existing test assertions.

---
*PR created automatically by Jules for task [1959929750053540565](https://jules.google.com/task/1959929750053540565) started by @cahyadsn*