### PR TITLE
🔒 Fix info exposure in reverse lookup API

### DIFF
--- a/apps/inc/reverse_lookup.php
+++ b/apps/inc/reverse_lookup.php
@@ -153,7 +153,8 @@ try {
         )
     );
 } catch (Throwable $e) {
-    $response = array('status' => false, 'error' => $e->getMessage());
+    error_log('Reverse lookup error: ' . $e->getMessage());
+    $response = array('status' => false, 'error' => 'Internal Server Error');
 }
 
 echo json_encode($response);

--- a/tests/apps/inc/ReverseLookupTest.php
+++ b/tests/apps/inc/ReverseLookupTest.php
@@ -38,8 +38,12 @@ class ReverseLookupTest extends TestCase
         $cwd = getcwd();
         chdir(dirname($this->reverseLookupFile));
 
+        $originalErrorLog = ini_get('error_log');
+        ini_set('error_log', '/dev/null');
+
         include basename($this->reverseLookupFile);
 
+        ini_set('error_log', $originalErrorLog);
         chdir($cwd);
 
         $output = ob_get_clean();
@@ -50,6 +54,6 @@ class ReverseLookupTest extends TestCase
         $this->assertArrayHasKey('status', $decoded);
         $this->assertFalse($decoded['status']);
         $this->assertArrayHasKey('error', $decoded);
-        $this->assertEquals('Mocked database failure', $decoded['error']);
+        $this->assertEquals('Internal Server Error', $decoded['error']);
     }
 }


### PR DESCRIPTION
This patch addresses an Information Exposure vulnerability in `apps/inc/reverse_lookup.php`. 

**What:** Previously, when an exception occurred during the reverse lookup query (such as a database error), the catch block returned the raw exception message (`$e->getMessage()`) directly to the client in the JSON response.

**Risk:** Returning raw exception messages to the client can expose sensitive internal server details, such as database schema structure, database connection strings, paths, or other environment information. This information could be leveraged by an attacker to map the backend and plan further targeted attacks.

**Solution:** The catch block was updated to log the actual error message server-side using `error_log()` for debugging purposes. Meanwhile, the JSON response returned to the client now uses a generic, sanitized error message (`'Internal Server Error'`).

The corresponding PHPUnit test (`tests/apps/inc/ReverseLookupTest.php`) has also been updated to assert the new generic message and to safely redirect `error_log` output during testing to prevent polluting the test results.

---
*PR created automatically by Jules for task [12080550871839731418](https://jules.google.com/task/12080550871839731418) started by @cahyadsn*