### PR TITLE
🧪 Add test coverage for theme parameter in change.color.php

### DIFF
--- a/tests/IndexGetParameterTest.php
+++ b/tests/IndexGetParameterTest.php
@@ -41,6 +41,10 @@ class IndexGetParameterTest extends TestCase
      */
     public function testValidGetIdLengthWithMockDb()
     {
+        // Suppress errors about failing to connect to invalid DB host
+        $original = ini_get('error_log');
+        ini_set('error_log', '/dev/null');
+
         $_GET['id'] = '11';
 
         // We will create a mock PDO to replace the one created in db.php
@@ -76,6 +80,7 @@ class IndexGetParameterTest extends TestCase
         $this->assertStringContainsString('Pilih Kota/Kabupaten', $output);
         $this->assertStringContainsString('11.01', $output);
         $this->assertStringContainsString('KAB. SIMEULUE', $output);
+        ini_set('error_log', $original);
     }
 
     protected function tearDown(): void

--- a/tests/apps/inc/ReverseLookupTest.php
+++ b/tests/apps/inc/ReverseLookupTest.php
@@ -22,9 +22,14 @@ class ReverseLookupTest extends TestCase
 
         putenv('DB_HOST=invalid');
 
+        $original = ini_get('error_log');
+        ini_set('error_log', '/dev/null');
+
         ob_start();
         require_once $this->dbFile;
         ob_get_clean();
+
+        ini_set('error_log', $original);
 
         $mockPdo = $this->createMock(PDO::class);
         $mockPdo->method('prepare')

--- a/tests/inc/ChangeColorTest.php
+++ b/tests/inc/ChangeColorTest.php
@@ -30,4 +30,66 @@ class ChangeColorTest extends TestCase
         $this->assertEquals('blue', $_SESSION['c'], 'Session variable "c" should match the POST "color".');
     }
 
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testThemeIsSetToLight()
+    {
+        $_POST = [];
+        $_POST['theme'] = 'light';
+
+        if (session_status() === PHP_SESSION_NONE) {
+            $_SESSION = [];
+        }
+
+        ob_start();
+        include $this->targetFile;
+        ob_get_clean();
+
+        $this->assertArrayHasKey('theme', $_SESSION, 'Session variable "theme" should be set.');
+        $this->assertEquals('light', $_SESSION['theme'], 'Session variable "theme" should be light.');
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testThemeIsSetToDark()
+    {
+        $_POST = [];
+        $_POST['theme'] = 'dark';
+
+        if (session_status() === PHP_SESSION_NONE) {
+            $_SESSION = [];
+        }
+
+        ob_start();
+        include $this->targetFile;
+        ob_get_clean();
+
+        $this->assertArrayHasKey('theme', $_SESSION, 'Session variable "theme" should be set.');
+        $this->assertEquals('dark', $_SESSION['theme'], 'Session variable "theme" should be dark.');
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testThemeIsSetToDarkForInvalidValues()
+    {
+        $_POST = [];
+        $_POST['theme'] = 'blue';
+
+        if (session_status() === PHP_SESSION_NONE) {
+            $_SESSION = [];
+        }
+
+        ob_start();
+        include $this->targetFile;
+        ob_get_clean();
+
+        $this->assertArrayHasKey('theme', $_SESSION, 'Session variable "theme" should be set.');
+        $this->assertEquals('dark', $_SESSION['theme'], 'Session variable "theme" should default to dark for invalid values.');
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of tests for the branch that handles the `theme` parameter in `apps/inc/change.color.php`.
📊 **Coverage:** Tests now cover setting the theme to 'light', setting it to 'dark', and defaulting to 'dark' for arbitrary invalid values.
✨ **Result:** Test coverage for `change.color.php` is now fully complete for both `color` and `theme` session updates.

Also cleaned up output in a couple of older tests that rely on invalid database connections.

---
*PR created automatically by Jules for task [2803040656763188945](https://jules.google.com/task/2803040656763188945) started by @cahyadsn*