### PR TITLE
🧪 Add missing edge cases for pointInRing test coverage

### DIFF
--- a/tests/inc/ReverseLookupTest.php
+++ b/tests/inc/ReverseLookupTest.php
@@ -64,6 +64,8 @@ class ReverseLookupTest extends TestCase
         $this->assertFalse(pointInRing(-5, 5, $ring));
 
         // Invalid ring (< 3 points)
+        $this->assertFalse(pointInRing(5, 5, []));
+        $this->assertFalse(pointInRing(5, 5, [[0, 0]]));
         $this->assertFalse(pointInRing(5, 5, [[0, 0], [0, 10]]));
     }
 


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses missing edge case coverage for the `pointInRing` function in `reverse_lookup.php`. Specifically, tests were lacking for edge case inputs with a length of less than 3 points (`[]`, `[[0,0]]`).

📊 **Coverage:** What scenarios are now tested
Tests for arrays of length 0, 1, and 2 points are now explicitly asserted to safely return false, in accordance with the `count($ring) < 3` condition logic.

✨ **Result:** The improvement in test coverage
More robust, specific safety checks to ensure `pointInRing` doesn't throw unexpected behaviors when an empty or overly small ring is provided as a geographic constraint. Tests run seamlessly.

---
*PR created automatically by Jules for task [13112425234380425795](https://jules.google.com/task/13112425234380425795) started by @cahyadsn*