### PR TITLE
🧹 Remove deprecated ActiveXObject fallback from ajax.js

### DIFF
--- a/apps/js/ajax.js
+++ b/apps/js/ajax.js
@@ -3,6 +3,5 @@
    ============================================================ */
 function do_ajax() {
     if (window.XMLHttpRequest) return new XMLHttpRequest();
-    if (window.ActiveXObject) return new ActiveXObject("Microsoft.XMLHTTP");
     return null;
 }


### PR DESCRIPTION
🎯 **What:** Removed the `ActiveXObject` fallback in `apps/js/ajax.js`.
💡 **Why:** `ActiveXObject("Microsoft.XMLHTTP")` was only used by legacy Internet Explorer browsers (IE6 and below). All modern browsers universally support `XMLHttpRequest` (or newer equivalents like `fetch`). Removing this code eliminates dead paths and improves code cleanliness.
✅ **Verification:** Verified that the function structurally preserves its purpose (returning `null` if `XMLHttpRequest` is not available), and ran the entire PHPUnit suite (`./vendor/bin/phpunit`) locally. Tests passed successfully.
✨ **Result:** A cleaner JavaScript AJAX utility with obsolete, deprecated functionality stripped out.

---
*PR created automatically by Jules for task [3939165736990606595](https://jules.google.com/task/3939165736990606595) started by @cahyadsn*