### PR TITLE
🔒 Fix XSS via unescaped database output

### DIFF
--- a/apps/inc/geo_ajax.php
+++ b/apps/inc/geo_ajax.php
@@ -89,7 +89,8 @@ if (!empty($_GET['id'])){
         $query->execute(array(':id'=>$_GET['id'],':m'=>$m));
         $opt_arr = ["<option value=''>Pilih {$wil}</option>"];
         while($d = $query->fetchObject()){
-            $opt_arr[] = "<option value='{$d->kode}'>{$d->nama}</option>";
+            $nama = htmlspecialchars($d->nama, ENT_QUOTES, 'UTF-8');
+            $opt_arr[] = "<option value='{$d->kode}'>{$nama}</option>";
         }
         $opt = implode('', $opt_arr);
         file_put_contents($cache_file, $opt, LOCK_EX);

--- a/apps/index.php
+++ b/apps/index.php
@@ -136,7 +136,8 @@ header('Pragma: cache');
                       $query->execute();
                       $arr = [];
                       while ($data=$query->fetchObject()){
-                        $arr[] = '<option value="'.$data->kode.'">'.$data->nama.'</option>';
+                        $nama = htmlspecialchars($data->nama, ENT_QUOTES, 'UTF-8');
+                        $arr[] = '<option value="'.$data->kode.'">'.$nama.'</option>';
                       }
                       $html = implode('', $arr);
                       file_put_contents($cache_file, $html, LOCK_EX);

--- a/index.php
+++ b/index.php
@@ -38,8 +38,10 @@ if (isset($_GET['id']) && !empty($_GET['id'])){
 		$query = $db->prepare("SELECT kode, nama FROM wilayah WHERE kode LIKE :id AND CHAR_LENGTH(kode)=:m ORDER BY nama");
 		$query->execute(array(':id'=>$_GET['id'].'%',':m'=>$wil[$n][0]));
 		echo"<option value=''>Pilih {$wil[$n][1]}</option>";
-		while($d = $query->fetchObject())
-			echo "<option value='{$d->kode}'>{$d->nama}</option>";
+		while($d = $query->fetchObject()) {
+			$nama = htmlspecialchars($d->nama, ENT_QUOTES, 'UTF-8');
+			echo "<option value='{$d->kode}'>{$nama}</option>";
+		}
 	}
 }else{
 ?>
@@ -120,7 +122,8 @@ if (isset($_GET['id']) && !empty($_GET['id'])){
 						$query->execute();
 						$arr = [];
 						while ($data=$query->fetchObject()){
-							$arr[] = '<option value="'.$data->kode.'">'.$data->nama.'</option>';
+							$nama = htmlspecialchars($data->nama, ENT_QUOTES, 'UTF-8');
+							$arr[] = '<option value="'.$data->kode.'">'.$nama.'</option>';
 						}
 						$html = implode('', $arr);
 						file_put_contents($cache_file, $html, LOCK_EX);


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was Cross-Site Scripting (XSS) due to unescaped database output.
⚠️ **Risk:** The potential impact if left unfixed would be that malicious actors could inject code into the webpage, allowing them to execute arbitrary scripts in a user's browser, steal session tokens, or deface the site if they somehow get an XSS payload saved into the database (e.g. by compromising the database itself or via another vector).
🛡️ **Solution:** The fix addresses the vulnerability by passing the database output (the `$d->nama` field in `<option>` tags) through `htmlspecialchars($d->nama, ENT_QUOTES, 'UTF-8')`. This converts special characters to their HTML entities, ensuring the output is always treated as data, rather than executable code. I have applied this fix not just to the reported `index.php:42` location, but to identical occurrences in `index.php:122`, `apps/index.php:138` and `apps/inc/geo_ajax.php:91`. Tests run successfully.

---
*PR created automatically by Jules for task [18238853527578774546](https://jules.google.com/task/18238853527578774546) started by @cahyadsn*