### PR TITLE
🔒 Fix security vulnerability by removing hardcoded root user from DB config

### DIFF
--- a/apps/inc/db.php
+++ b/apps/inc/db.php
@@ -24,7 +24,7 @@ See the MIT License for more details
 copyright (c) 2015-2026 by cahya dsn; cahyadsn@gmail.com
 ================================================================================*/
 $dbhost = getenv('DB_HOST') !== false ? getenv('DB_HOST') : 'localhost';
-$dbuser = getenv('DB_USER') !== false ? getenv('DB_USER') : 'root';
+$dbuser = getenv('DB_USER') !== false ? getenv('DB_USER') : '';
 $dbpass = getenv('DB_PASS') !== false ? getenv('DB_PASS') : '';
 $dbname = getenv('DB_NAME') !== false ? getenv('DB_NAME') : 'wilayah';
 $db_dsn = "mysql:dbname=$dbname;host=$dbhost";

--- a/tests/AppsIncDbTest.php
+++ b/tests/AppsIncDbTest.php
@@ -31,7 +31,7 @@ class AppsIncDbTest extends TestCase
         ob_get_clean();
 
         $this->assertEquals('localhost', $dbhost);
-        $this->assertEquals('root', $dbuser);
+        $this->assertEquals('', $dbuser);
         $this->assertEquals('', $dbpass);
         $this->assertEquals('wilayah', $dbname);
         $this->assertEquals("mysql:dbname=wilayah;host=localhost", $db_dsn);


### PR DESCRIPTION
🎯 **What:** The database connection configuration in `apps/inc/db.php` had a hardcoded default user of `root`. This has been changed to default to an empty string (`''`) when the `DB_USER` environment variable is not provided. The `tests/AppsIncDbTest.php` has been updated to assert the new expected default behavior.

⚠️ **Risk:** Hardcoding default credentials, particularly a highly privileged user like `root`, is a significant security risk. If the application is deployed into an environment where the `DB_USER` environment variable is accidentally omitted or misconfigured, the application would automatically attempt to connect to the database as `root` with no password. This could lead to a severe security breach if the local database is accessible or misconfigured.

🛡️ **Solution:** The fix replaces the default `'root'` value with an empty string `''`. This implements a secure-by-default behavior: if the environment variable is missing, the application will intentionally fail to connect to the database (which is the expected and secure outcome) rather than silently upgrading privileges to `root`. All related test assertions have been updated to reflect the new expected behavior, and the test suite has been verified to pass locally.

---
*PR created automatically by Jules for task [17217425811820632110](https://jules.google.com/task/17217425811820632110) started by @cahyadsn*