### PR TITLE
🔒 Fix DOM-based XSS in dropdown option population

### DIFF
--- a/apps/inc/geo_js.php
+++ b/apps/inc/geo_js.php
@@ -31,6 +31,22 @@ if(isset($_SESSION['author']) && $_SESSION['author']=='cahyadsn'){
 var ids, my_id, my_z;
 var wil = new Array('prov', 'kota', 'kec', 'kel');
 
+function setSafeSelectOptions(selectElement, optionsHtml) {
+    selectElement.innerHTML = '';
+    var parser = new DOMParser();
+    var doc = parser.parseFromString('<select>' + (optionsHtml || '') + '</select>', 'text/html');
+    var options = doc.querySelectorAll('option');
+    for (var i = 0; i < options.length; i++) {
+        var opt = document.createElement('option');
+        opt.value = options[i].getAttribute('value') || '';
+        opt.textContent = options[i].textContent;
+        if (options[i].hasAttribute('selected')) {
+            opt.setAttribute('selected', 'selected');
+        }
+        selectElement.appendChild(opt);
+    }
+}
+
 // --- AJAX helpers ---
 
 var my_ajax = do_ajax();
@@ -89,7 +105,7 @@ function loadChildren(parentKode, targetSelectId, targetBoxId) {
         .then(function(result) {
             var select = document.getElementById(targetSelectId);
             var box = document.getElementById(targetBoxId);
-            if (select && result.opt) select.innerHTML = result.opt;
+            if (select && result.opt) setSafeSelectOptions(select, result.opt);
             if (box) box.style.display = 'block';
             return result;
         });
@@ -441,7 +457,7 @@ function stateChanged() {
         if (idx > 0) {
             var sel = document.getElementById(wil[idx]);
             if (sel && d.opt) {
-                sel.innerHTML = d.opt;
+                setSafeSelectOptions(sel, d.opt);
                 sel.focus();
             }
         }


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was a DOM-based XSS where unsanitized HTML strings from an AJAX response were directly assigned to `innerHTML` of select elements in `geo_js.php`.
⚠️ **Risk:** If an attacker managed to compromise the response or the backend emitted malformed payload containing malicious attributes (like `onerror` in `img` tags or `<script>` tags if rendered differently), it could lead to arbitrary JavaScript execution in the client's browser (DOM XSS).
🛡️ **Solution:** Implemented a new secure helper function `setSafeSelectOptions` that takes advantage of `DOMParser` to parse the incoming HTML string into an inert DOM document (where scripts cannot execute), securely extracts only the `<option>` elements, and rebuilds the dropdown using `document.createElement`. Replaced the vulnerable assignments at lines 92 and 444 with calls to this secure helper.

---
*PR created automatically by Jules for task [5608049336308692781](https://jules.google.com/task/5608049336308692781) started by @cahyadsn*