### PR TITLE
🔒 fix: Escape 'kode' attribute to prevent XSS

### DIFF
--- a/apps/inc/geo_ajax.php
+++ b/apps/inc/geo_ajax.php
@@ -89,8 +89,9 @@ if (!empty($_GET['id'])){
         $query->execute(array(':id'=>$_GET['id'],':m'=>$m));
         $opt_arr = ["<option value=''>Pilih {$wil}</option>"];
         while($d = $query->fetchObject()){
+            $kode = htmlspecialchars($d->kode, ENT_QUOTES, 'UTF-8');
             $nama = htmlspecialchars($d->nama, ENT_QUOTES, 'UTF-8');
-            $opt_arr[] = "<option value='{$d->kode}'>{$nama}</option>";
+            $opt_arr[] = "<option value='{$kode}'>{$nama}</option>";
         }
         $opt = implode('', $opt_arr);
         file_put_contents($cache_file, $opt, LOCK_EX);

--- a/apps/index.php
+++ b/apps/index.php
@@ -136,8 +136,9 @@ header('Pragma: cache');
                       $query->execute();
                       $arr = [];
                       while ($data=$query->fetchObject()){
+                        $kode = htmlspecialchars($data->kode, ENT_QUOTES, 'UTF-8');
                         $nama = htmlspecialchars($data->nama, ENT_QUOTES, 'UTF-8');
-                        $arr[] = '<option value="'.$data->kode.'">'.$nama.'</option>';
+                        $arr[] = '<option value="'.$kode.'">'.$nama.'</option>';
                       }
                       $html = implode('', $arr);
                       file_put_contents($cache_file, $html, LOCK_EX);

--- a/index.php
+++ b/index.php
@@ -39,8 +39,9 @@ if (isset($_GET['id']) && !empty($_GET['id'])){
 		$query->execute(array(':id'=>$_GET['id'].'%',':m'=>$wil[$n][0]));
 		echo"<option value=''>Pilih {$wil[$n][1]}</option>";
 		while($d = $query->fetchObject()) {
+			$kode = htmlspecialchars($d->kode, ENT_QUOTES, 'UTF-8');
 			$nama = htmlspecialchars($d->nama, ENT_QUOTES, 'UTF-8');
-			echo "<option value='{$d->kode}'>{$nama}</option>";
+			echo "<option value='{$kode}'>{$nama}</option>";
 		}
 	}
 }else{
@@ -122,8 +123,9 @@ if (isset($_GET['id']) && !empty($_GET['id'])){
 						$query->execute();
 						$arr = [];
 						while ($data=$query->fetchObject()){
+							$kode = htmlspecialchars($data->kode, ENT_QUOTES, 'UTF-8');
 							$nama = htmlspecialchars($data->nama, ENT_QUOTES, 'UTF-8');
-							$arr[] = '<option value="'.$data->kode.'">'.$nama.'</option>';
+							$arr[] = '<option value="'.$kode.'">'.$nama.'</option>';
 						}
 						$html = implode('', $arr);
 						file_put_contents($cache_file, $html, LOCK_EX);


### PR DESCRIPTION
🎯 **What:** Fixed an XSS vulnerability where database fields used in HTML attributes were not properly escaped.
⚠️ **Risk:** An attacker could potentially inject malicious scripts into the page if the `kode` field contained unescaped characters like double quotes (e.g., `"><script>...`).
🛡️ **Solution:** Wrapped the output of `$data->kode` with `htmlspecialchars($data->kode, ENT_QUOTES, 'UTF-8')` to safely encode any malicious characters before injecting it into the HTML `<option>` value attribute. This was applied to `index.php`, `apps/index.php`, and `apps/inc/geo_ajax.php`.

---
*PR created automatically by Jules for task [9502502353757910276](https://jules.google.com/task/9502502353757910276) started by @cahyadsn*