### PR TITLE
🔒 Fix insecure temporary directory for geo options cache file

### DIFF
--- a/apps/inc/geo_ajax.php
+++ b/apps/inc/geo_ajax.php
@@ -79,7 +79,11 @@ if (!empty($_GET['id'])){
     $m=($n==2?5:($n==5?8:13));
     $wil=($n==2?'Kota/Kab':($n==5?'Kecamatan':'Desa/Kelurahan'));
 
-    $cache_file = sys_get_temp_dir() . '/geo_opt_cache_' . md5($_GET['id']) . '.html';
+    $cache_dir = dirname(__DIR__) . '/cache';
+    if (!is_dir($cache_dir)) {
+        mkdir($cache_dir, 0755, true);
+    }
+    $cache_file = $cache_dir . '/geo_opt_cache_' . md5($_GET['id']) . '.html';
     $cache_ttl = 86400; // 1 day
 
     if (file_exists($cache_file) && (time() - filemtime($cache_file) < $cache_ttl)) {


### PR DESCRIPTION
* 🎯 **What:** Fixed a vulnerability where the geo options cache file in `apps/inc/geo_ajax.php` was being written to the shared system temporary directory (`sys_get_temp_dir()`).
* ⚠️ **Risk:** Writing cache files to a shared system temporary directory allows potential read and write access by other users or processes on shared environments, leading to potential local data disclosure or cache poisoning.
* 🛡️ **Solution:** Modified the script to store the cache file inside the application's localized `cache` directory (`dirname(__DIR__) . '/cache'`), which is specific to the application, eliminating the cross-user access risk.

---
*PR created automatically by Jules for task [8693935933678727067](https://jules.google.com/task/8693935933678727067) started by @cahyadsn*