### PR TITLE
🔒 fix: secure cache file storage by replacing sys_get_temp_dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ composer.lock
 /.Jules
 /MEMORY.md
 /GEMINI.md
+# Local application cache files
+/cache/*
+!/cache/.gitkeep
+/apps/cache/*
+!/apps/cache/.gitkeep

--- a/apps/inc/geo_ajax.php
+++ b/apps/inc/geo_ajax.php
@@ -79,7 +79,7 @@ if (!empty($_GET['id'])){
     $m=($n==2?5:($n==5?8:13));
     $wil=($n==2?'Kota/Kab':($n==5?'Kecamatan':'Desa/Kelurahan'));
 
-    $cache_file = sys_get_temp_dir() . '/geo_opt_cache_' . md5($_GET['id']) . '.html';
+    $cache_file = __DIR__ . '/../cache/geo_opt_cache_' . md5($_GET['id']) . '.html';
     $cache_ttl = 86400; // 1 day
 
     if (file_exists($cache_file) && (time() - filemtime($cache_file) < $cache_ttl)) {

--- a/index.php
+++ b/index.php
@@ -112,7 +112,7 @@ if (isset($_GET['id']) && !empty($_GET['id'])){
 				<select id="prov" onchange="ajax(this.value)">
 					<option value="">Provinsi</option>
 					<?php 
-					$cache_file = sys_get_temp_dir() . '/provinsi_cache.html';
+					$cache_file = __DIR__ . '/cache/provinsi_cache.html';
 					$cache_ttl = 86400;
 
 					if (file_exists($cache_file) && (time() - filemtime($cache_file) < $cache_ttl)) {


### PR DESCRIPTION
🎯 **What:** Replaced the use of `sys_get_temp_dir()` with local application-specific `cache/` directories for storing HTML cache files in `index.php` and `apps/inc/geo_ajax.php`. Added `.gitignore` rules and `.gitkeep` files to manage the cache directories correctly without tracking the cache content itself.
⚠️ **Risk:** Storing cache files in `sys_get_temp_dir()` (e.g. `/tmp`) in shared hosting environments is insecure, as other local users might be able to read or arbitrarily overwrite these cache files (potentially leading to cache poisoning or privilege escalation).
🛡️ **Solution:** Switched the cache location to `__DIR__ . '/cache/'` in `index.php` and `__DIR__ . '/../cache/'` in `apps/inc/geo_ajax.php`. This isolates the cache files within the application's directory, ensuring they are only accessible to the application owner.

---
*PR created automatically by Jules for task [12605174834558513379](https://jules.google.com/task/12605174834558513379) started by @cahyadsn*