### PR TITLE
🧪 Add test for invalid JSON path in geo_update

### DIFF
--- a/tests/apps/inc/GeoUpdateTest.php
+++ b/tests/apps/inc/GeoUpdateTest.php
@@ -124,6 +124,33 @@ PHP;
         $this->assertEquals('No valid fields to update', $decoded['msg']);
     }
 
+    public function testInvalidJsonPath()
+    {
+        $_POST['id'] = '1234';
+        $_POST['path'] = 'invalid_json';
+
+        putenv('DB_HOST=127.0.0.1');
+
+        $originalErrorLog = ini_get('error_log');
+        ini_set('error_log', '/dev/null');
+        ob_start();
+        @require_once $this->dbFile;
+        ob_end_clean();
+        ini_set('error_log', $originalErrorLog);
+
+        ob_start();
+        $cwd = getcwd();
+        chdir(dirname($this->geoUpdateFile));
+        @include basename($this->geoUpdateFile);
+        chdir($cwd);
+        $output = ob_get_clean();
+
+        $this->assertJson($output);
+        $decoded = json_decode($output, true);
+        $this->assertFalse($decoded['status']);
+        $this->assertEquals('No valid fields to update', $decoded['msg']);
+    }
+
     public function testValidUpdate()
     {
         $_POST['id'] = '1234';


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is when passing an invalid JSON string to the `path` field of the `geo_update.php` endpoint.
📊 **Coverage:** The test ensures that an invalid JSON path rejects the update without crashing the application.
✨ **Result:** Test coverage for `geo_update.php` is improved with tests specifically handling the case of an unparseable JSON array being passed.

---
*PR created automatically by Jules for task [12406209579324431530](https://jules.google.com/task/12406209579324431530) started by @cahyadsn*