### PR TITLE
🔒 Fix XSS vulnerability in geo_update.php via unescaped JSON output

### DIFF
--- a/apps/inc/geo_update.php
+++ b/apps/inc/geo_update.php
@@ -29,8 +29,11 @@ session_set_cookie_params([
     'samesite' => 'Strict'
 ]);
 session_start();
+
+header('Content-Type: application/json; charset=utf-8');
+
 if (!isset($_SESSION['author']) || $_SESSION['author'] !== 'cahyadsn') {
-    die(json_encode(array('status' => false, 'msg' => 'unauthorized')));
+    die(json_encode(array('status' => false, 'msg' => 'unauthorized'), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP));
 }
 
 require_once "db.php";
@@ -63,4 +66,4 @@ if(isset($_POST['id'])){
     $r=array('status'=>false,'msg'=>'No valid fields to update');
   }
 }
-echo json_encode($r);
+echo json_encode($r, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP);


### PR DESCRIPTION
🎯 **What:** Fixed a Cross-Site Scripting (XSS) vulnerability in `apps/inc/geo_update.php` caused by unescaped JSON output without a proper Content-Type header.
⚠️ **Risk:** Because the endpoint returned JSON without specifying `Content-Type: application/json`, browsers could potentially interpret the response as HTML. This allowed for an XSS vulnerability if malicious data was echoed back in the response (e.g. from `$sql.json_encode($data)` or even if user input was reflected).
🛡️ **Solution:**
- Added `header('Content-Type: application/json; charset=utf-8');` to ensure browsers interpret the response strictly as JSON.
- Updated all `json_encode()` calls to include the flags `JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP` to safely encode output and avoid executing any stray HTML/JS context.

---
*PR created automatically by Jules for task [10049751684163769487](https://jules.google.com/task/10049751684163769487) started by @cahyadsn*