### PR TITLE
🧹 Remove unused variable assignment in geo_js.php

### DIFF
--- a/apps/inc/geo_js.php
+++ b/apps/inc/geo_js.php
@@ -21,9 +21,7 @@ header("Content-type: text/javascript");
 header('Cache-Control: public, max-age=31536000');
 header('Expires: ' . gmdate('D, d M Y H:i:s \G\M\T', time() + 31536000));
 header('Pragma: cache');
-if(isset($_SESSION['author']) && $_SESSION['author']=='cahyadsn'){
-    $v=$_GET['v'];
-} else {
+if (!isset($_SESSION['author']) || $_SESSION['author'] !== 'cahyadsn') {
     die('illegal call');
 }
 ?>


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed the unused variable assignment `$v = $_GET['v'];` in `apps/inc/geo_js.php` inside the authorization check. 

💡 **Why:** How this improves maintainability
The variable was captured but never used, resulting in dead code. Removing it cleans up the file. By inverting the if-condition to an early exit (`die('illegal call');`), the code flow becomes simpler and aligns with the pattern used in other files such as `apps/inc/geo_update.php`.

✅ **Verification:** How you confirmed the change is safe
Ran `php -l apps/inc/geo_js.php` to verify there are no syntax errors. Successfully ran the full test suite (`./vendor/bin/phpunit`) against the local MariaDB database, ensuring no existing functionality was broken by the change.

✨ **Result:** The improvement achieved
A cleaner, more readable `geo_js.php` without dead code, employing a consistent early-exit pattern for authorization.

---
*PR created automatically by Jules for task [17843083717610487118](https://jules.google.com/task/17843083717610487118) started by @cahyadsn*