### PR TITLE
🔒 Fix weak password verification by implementing password_verify

### DIFF
--- a/apps/login.php
+++ b/apps/login.php
@@ -22,7 +22,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $expectedUser = getenv('ADMIN_USER');
     $expectedPass = getenv('ADMIN_PASS');
 
-    if ($expectedUser && $expectedPass && $username === $expectedUser && is_string($password) && hash_equals($expectedPass, $password)) {
+    if ($expectedUser && $expectedPass && $username === $expectedUser && is_string($password) && password_verify($password, $expectedPass)) {
         $_SESSION['author'] = 'cahyadsn'; // Value expected by geo_update.php
         header("Location: index.php");
         exit;

--- a/tests/AppsLoginTest.php
+++ b/tests/AppsLoginTest.php
@@ -49,7 +49,7 @@ class AppsLoginTest extends TestCase
         $_POST['password'] = 'secret';
 
         putenv('ADMIN_USER=admin');
-        putenv('ADMIN_PASS=secret');
+        putenv('ADMIN_PASS=' . password_hash('secret', PASSWORD_DEFAULT));
 
         $output = $this->runLoginScript();
 
@@ -71,7 +71,7 @@ class AppsLoginTest extends TestCase
         $_POST['password'] = 'wrong_secret';
 
         putenv('ADMIN_USER=admin');
-        putenv('ADMIN_PASS=secret');
+        putenv('ADMIN_PASS=' . password_hash('secret', PASSWORD_DEFAULT));
 
         $output = $this->runLoginScript();
 


### PR DESCRIPTION
🎯 **What:** Replaced the weak `hash_equals()` string comparison with `password_verify()` in `apps/login.php` and updated corresponding test files to match the hashed password logic.
⚠️ **Risk:** Using `hash_equals` against environment variables expects a plaintext password in configuration or memory, which exposes the credentials unnecessarily.
🛡️ **Solution:** `password_verify()` resolves this issue by natively handling securely hashed passwords. The test environment was updated to use `password_hash()` for simulating `ADMIN_PASS` properly.

---
*PR created automatically by Jules for task [13232824952055572327](https://jules.google.com/task/13232824952055572327) started by @cahyadsn*