### PR TITLE
🔒 Fix missing CSRF validation in geo_update.php

### DIFF
--- a/apps/inc/geo_update.php
+++ b/apps/inc/geo_update.php
@@ -36,6 +36,10 @@ if (!isset($_SESSION['author']) || $_SESSION['author'] !== 'cahyadsn') {
     die(json_encode(array('status' => false, 'msg' => 'unauthorized'), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP));
 }
 
+if (empty($_POST['csrf_token']) || empty($_SESSION['csrf_token']) || !is_string($_POST['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])) {
+    die(json_encode(array('status' => false, 'msg' => 'csrf token validation failed'), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP));
+}
+
 require_once "db.php";
 $r=array('status'=>false,'msg'=>'do nothing');
 $fields=array('lat','lng','path');

--- a/tests/apps/inc/GeoUpdateTest.php
+++ b/tests/apps/inc/GeoUpdateTest.php
@@ -20,9 +20,11 @@ class GeoUpdateTest extends TestCase
 
         // Setup default authorized session for tests that don't want to die()
         $_SESSION['author'] = 'cahyadsn';
+        $_SESSION['csrf_token'] = 'test_token';
 
         // Reset $_POST
         $_POST = [];
+        $_POST['csrf_token'] = 'test_token';
     }
 
     public function testUnauthorizedAccessNoSession()
@@ -46,6 +48,54 @@ PHP;
         $decoded = json_decode($output, true);
         $this->assertFalse($decoded['status']);
         $this->assertEquals('unauthorized', $decoded['msg']);
+    }
+
+    public function testCsrfTokenMissing()
+    {
+        $script = <<<PHP
+<?php
+session_start();
+\$_SESSION['author'] = 'cahyadsn';
+\$_SESSION['csrf_token'] = 'test_token';
+// \$_POST['csrf_token'] is missing
+ob_start();
+@include '{$this->geoUpdateFile}';
+\$output = ob_get_clean();
+echo \$output;
+PHP;
+        $tmpFile = tempnam(sys_get_temp_dir(), 'test_');
+        file_put_contents($tmpFile, $script);
+        $output = exec('php ' . escapeshellarg($tmpFile) . ' 2>/dev/null');
+        unlink($tmpFile);
+
+        $this->assertJson($output);
+        $decoded = json_decode($output, true);
+        $this->assertFalse($decoded['status']);
+        $this->assertEquals('csrf token validation failed', $decoded['msg']);
+    }
+
+    public function testCsrfTokenInvalid()
+    {
+        $script = <<<PHP
+<?php
+session_start();
+\$_SESSION['author'] = 'cahyadsn';
+\$_SESSION['csrf_token'] = 'test_token';
+\$_POST['csrf_token'] = 'wrong_token';
+ob_start();
+@include '{$this->geoUpdateFile}';
+\$output = ob_get_clean();
+echo \$output;
+PHP;
+        $tmpFile = tempnam(sys_get_temp_dir(), 'test_');
+        file_put_contents($tmpFile, $script);
+        $output = exec('php ' . escapeshellarg($tmpFile) . ' 2>/dev/null');
+        unlink($tmpFile);
+
+        $this->assertJson($output);
+        $decoded = json_decode($output, true);
+        $this->assertFalse($decoded['status']);
+        $this->assertEquals('csrf token validation failed', $decoded['msg']);
     }
 
     public function testUnauthorizedAccessWrongAuthor()


### PR DESCRIPTION
🎯 **What:** Added missing CSRF validation in `apps/inc/geo_update.php` and updated tests.
⚠️ **Risk:** Without a CSRF check, an attacker could force an authenticated administrator to unintentionally execute state-changing requests (like modifying geographic coordinates or paths) if they visited a malicious site while logged in.
🛡️ **Solution:** Added a robust CSRF check block that validates `$_POST['csrf_token']` against `$_SESSION['csrf_token']` using `hash_equals()`. Ensure `$_POST['csrf_token']` is a string to prevent TypeErrors, returning an appropriate JSON failure response if validation fails. Updated `GeoUpdateTest.php` to provide default test tokens and added two new isolated test cases for missing and invalid CSRF tokens.

---
*PR created automatically by Jules for task [18374693993717359964](https://jules.google.com/task/18374693993717359964) started by @cahyadsn*