### PR TITLE
🔒 fix wildcard injection in database queries

### DIFF
--- a/apps/inc/geo_ajax.php
+++ b/apps/inc/geo_ajax.php
@@ -92,7 +92,7 @@ if (!empty($_GET['id'])){
         $opt = file_get_contents($cache_file);
     } else {
         $query = $db->prepare("SELECT kode, nama FROM {$tbl_wilayah} WHERE kode LIKE CONCAT(:id, '%') AND CHAR_LENGTH(kode)=:m ORDER BY nama");
-        $query->execute(array(':id'=>$_GET['id'],':m'=>$m));
+        $query->execute(array(':id'=>addcslashes($_GET['id'], '%_\\'),':m'=>$m));
         $opt_arr = ["<option value=''>Pilih {$wil}</option>"];
         while($d = $query->fetchObject()){
             $kode = htmlspecialchars($d->kode, ENT_QUOTES, 'UTF-8');

--- a/index.php
+++ b/index.php
@@ -36,7 +36,7 @@ if (isset($_GET['id']) && !empty($_GET['id'])){
 	$n=strlen($_GET['id']);
 	if (isset($wil[$n])) {
 		$query = $db->prepare("SELECT kode, nama FROM wilayah WHERE kode LIKE :id AND CHAR_LENGTH(kode)=:m ORDER BY nama");
-		$query->execute(array(':id'=>$_GET['id'].'%',':m'=>$wil[$n][0]));
+		$query->execute(array(':id'=>addcslashes($_GET['id'], '%_\\').'%',':m'=>$wil[$n][0]));
 		echo"<option value=''>Pilih {$wil[$n][1]}</option>";
 		while($d = $query->fetchObject()) {
 			$kode = htmlspecialchars($d->kode, ENT_QUOTES, 'UTF-8');


### PR DESCRIPTION
🎯 **What:** Fixed wildcard injection vulnerabilities in `index.php` and `apps/inc/geo_ajax.php` where unsanitized user input was appended to or passed into SQL `LIKE` clauses.

⚠️ **Risk:** Although PDO prepared statements protect against traditional SQL injection (e.g. `' OR 1=1`), they do not escape `%` or `_` characters. Attackers could send `%` to perform unintended global queries, causing performance degradation, unintended data extraction, or a Denial of Service (DoS) by forcing full table scans on large database sets.

🛡️ **Solution:** Passed the user input `$_GET['id']` through `addcslashes($val, '%_\\')` to explicitly escape all potential wildcard and escape characters before binding the parameters to the PDO queries. This restricts the inputs to literal prefix matching as originally intended.

---
*PR created automatically by Jules for task [2297982586479817499](https://jules.google.com/task/2297982586479817499) started by @cahyadsn*