### PR TITLE
🧹 Remove unused session variable $_SESSION['ver']

### DIFF
--- a/apps/index.php
+++ b/apps/index.php
@@ -24,7 +24,6 @@ if (empty($_SESSION['csrf_token'])) {
 }
 $theme=isset($_SESSION['theme'])?$_SESSION['theme']:(isset($_GET['theme'])?$_GET['theme']:'light');
 define("_AUTHOR","cahyadsn");
-$_SESSION['ver']=sha1(rand());
 require_once 'inc/db.php';
 $version='3.0.1';
 header('Expires: '.gmdate('D, d M Y H:i:s \G\M\T', time() + 86400));

--- a/tests/apps/index_php_test.php
+++ b/tests/apps/index_php_test.php
@@ -89,9 +89,6 @@ class IndexPhpTest extends TestCase
 
         $this->assertStringNotContainsString('$_SESSION[\'author\']=\'cahyadsn\'', $content,
             'Session author should not be hardcoded in index.php');
-
-        $this->assertStringContainsString('$_SESSION[\'ver\']', $content,
-            'Session version must be set');
     }
 
     /**


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed the dead code `$_SESSION['ver']=sha1(rand());` from `apps/index.php` and the corresponding assertion from `tests/apps/index_php_test.php`.

💡 **Why:** How this improves maintainability
The session variable was initialized but never used elsewhere in the application. Removing dead code reduces cognitive load for developers and cleans up the session state.

✅ **Verification:** How you confirmed the change is safe
Ran the full PHPUnit test suite. The tests verify that the change does not break functionality, and the updated test no longer erroneously asserts for the removed session variable.

✨ **Result:** The improvement achieved
A cleaner `apps/index.php` without redundant session state assignments.

---
*PR created automatically by Jules for task [7310221888988640161](https://jules.google.com/task/7310221888988640161) started by @cahyadsn*