### PR TITLE
🧪 test: add unit tests for buildChain in reverse_lookup.php

### DIFF
--- a/tests/apps/inc/ReverseLookupTest.php
+++ b/tests/apps/inc/ReverseLookupTest.php
@@ -11,6 +11,110 @@ class ReverseLookupTest extends TestCase
     private $dbFile = __DIR__ . '/../../../apps/inc/db.php';
     private $reverseLookupFile = __DIR__ . '/../../../apps/inc/reverse_lookup.php';
 
+    private function loadReverseLookupFunctions()
+    {
+        if (function_exists('buildChain')) {
+            return;
+        }
+
+        $originalGet = $_GET;
+        $originalDb = isset($GLOBALS['db']) ? $GLOBALS['db'] : null;
+
+        $_GET['lat'] = '0';
+        $_GET['lng'] = '0';
+
+        $mockPdo = $this->createMock(PDO::class);
+        $mockPdo->method('prepare')->willThrowException(new PDOException('Mocked'));
+        $GLOBALS['db'] = $mockPdo;
+
+        $tempLogFile = sys_get_temp_dir() . '/test_error_reverse_lookup.log';
+        $originalErrorLog = ini_get('error_log');
+        ini_set('error_log', $tempLogFile);
+
+        ob_start();
+        $cwd = getcwd();
+        chdir(dirname($this->reverseLookupFile));
+        @require_once basename($this->reverseLookupFile);
+        chdir($cwd);
+        ob_end_clean();
+
+        ini_set('error_log', $originalErrorLog);
+        @unlink($tempLogFile);
+
+        $_GET = $originalGet;
+        if ($originalDb !== null) {
+            $GLOBALS['db'] = $originalDb;
+        } else {
+            unset($GLOBALS['db']);
+        }
+    }
+
+    public function testBuildChainFull()
+    {
+        $this->loadReverseLookupFunctions();
+
+        $kode = '11.01.01.2001';
+        $names = [
+            '11' => 'ACEH',
+            '11.01' => 'KABUPATEN ACEH SELATAN',
+            '11.01.01' => 'BAKONGAN',
+            '11.01.01.2001' => 'KEUDE BAKONGAN'
+        ];
+
+        $expected = [
+            'prov' => ['kode' => '11', 'nama' => 'ACEH'],
+            'kab'  => ['kode' => '11.01', 'nama' => 'KABUPATEN ACEH SELATAN'],
+            'kec'  => ['kode' => '11.01.01', 'nama' => 'BAKONGAN'],
+            'kel'  => ['kode' => '11.01.01.2001', 'nama' => 'KEUDE BAKONGAN']
+        ];
+
+        $result = buildChain($kode, $names);
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testBuildChainPartial()
+    {
+        $this->loadReverseLookupFunctions();
+
+        $kode = '32.73'; // Only Province and Kabupaten/Kota
+        $names = [
+            '32' => 'JAWA BARAT',
+            '32.73' => 'KOTA BANDUNG'
+        ];
+
+        $expected = [
+            'prov' => ['kode' => '32', 'nama' => 'JAWA BARAT'],
+            'kab'  => ['kode' => '32.73', 'nama' => 'KOTA BANDUNG'],
+            'kec'  => null,
+            'kel'  => null
+        ];
+
+        $result = buildChain($kode, $names);
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testBuildChainMissingNames()
+    {
+        $this->loadReverseLookupFunctions();
+
+        $kode = '31.01.01'; // Prov, Kab, Kec
+        $names = [
+            '31' => 'DKI JAKARTA',
+            // Missing Kab name
+            '31.01.01' => 'KEPULAUAN SERIBU UTARA'
+        ];
+
+        $expected = [
+            'prov' => ['kode' => '31', 'nama' => 'DKI JAKARTA'],
+            'kab'  => ['kode' => '31.01', 'nama' => null], // Name should be null
+            'kec'  => ['kode' => '31.01.01', 'nama' => 'KEPULAUAN SERIBU UTARA'],
+            'kel'  => null
+        ];
+
+        $result = buildChain($kode, $names);
+        $this->assertEquals($expected, $result);
+    }
+
     /**
      * @runInSeparateProcess
      * @preserveGlobalState disabled


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The pure `buildChain` function in `apps/inc/reverse_lookup.php` lacked unit test coverage. Because the file is a procedural script that handles database queries and exits early under certain conditions, a mechanism was needed to cleanly expose and test just the function.

📊 **Coverage:** What scenarios are now tested
1. **Full Chain**: Tests generating an array with prov, kab, kec, and kel data with corresponding names.
2. **Partial Chain**: Tests properly omitting lower administrative levels when parsing short string codes (e.g., `32.73`).
3. **Missing Names**: Tests handling of missing location names in the `$names` mapping argument.

✨ **Result:** The improvement in test coverage
`buildChain` logic is now fully tested across edge cases. Test isolation is maintained by temporarily mocking `PDO` to halt the main execution script cleanly by tossing an expected exception during prepare(), and properly restoring `$_GET` and `$GLOBALS['db']` global state in the setup routine.

---
*PR created automatically by Jules for task [18440258898667837292](https://jules.google.com/task/18440258898667837292) started by @cahyadsn*