### PR TITLE
🧹 Remove unnecessary commented-out code in login.php

### DIFF
--- a/apps/login.php
+++ b/apps/login.php
@@ -6,7 +6,6 @@ session_set_cookie_params([
 ]);
 session_start();
 
-// Handle logout if requested (optional fallback or cleanup)
 if (isset($_GET['logout'])) {
     session_destroy();
     header("Location: index.php");


### PR DESCRIPTION
🎯 **What:** Removed an unnecessary line of comment (`// Handle logout if requested (optional fallback or cleanup)`) from `apps/login.php`.
💡 **Why:** This comment acts as a form of pseudo-code that is no longer needed since the block directly underneath it clearly handles the logout request logic, thus improving readability.
✅ **Verification:** Ran `DB_USER=root ./vendor/bin/phpunit` and observed that all 79 tests passed successfully. Reviewed the code changes to ensure only the comment was removed without touching any behavior.
✨ **Result:** A slightly cleaner and more readable `login.php` script.

---
*PR created automatically by Jules for task [922785301377758693](https://jules.google.com/task/922785301377758693) started by @cahyadsn*