### PR TITLE
🧪 Add unit tests for session configuration in session.php

### DIFF
--- a/tests/apps/inc/SessionTest.php
+++ b/tests/apps/inc/SessionTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class SessionTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     */
+    public function testSessionStartsAndConfiguresHttp()
+    {
+        $_SERVER['HTTPS'] = 'off';
+
+        require __DIR__ . '/../../../apps/inc/session.php';
+
+        $this->assertEquals(PHP_SESSION_ACTIVE, session_status());
+
+        $params = session_get_cookie_params();
+        $this->assertFalse($params['secure']);
+        $this->assertTrue($params['httponly']);
+        $this->assertEquals('Strict', $params['samesite']);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testSessionStartsAndConfiguresHttps()
+    {
+        $_SERVER['HTTPS'] = 'on';
+
+        require __DIR__ . '/../../../apps/inc/session.php';
+
+        $this->assertEquals(PHP_SESSION_ACTIVE, session_status());
+
+        $params = session_get_cookie_params();
+        $this->assertTrue($params['secure']);
+        $this->assertTrue($params['httponly']);
+        $this->assertEquals('Strict', $params['samesite']);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testSessionDoesNotRestartIfAlreadyActive()
+    {
+        // Start a session with some custom params
+        session_set_cookie_params([
+            'secure' => false,
+            'httponly' => false,
+            'samesite' => 'Lax'
+        ]);
+        session_start();
+
+        $this->assertEquals(PHP_SESSION_ACTIVE, session_status());
+
+        // This shouldn't do anything because session is active
+        require __DIR__ . '/../../../apps/inc/session.php';
+
+        // Assert params haven't changed
+        $params = session_get_cookie_params();
+        $this->assertFalse($params['secure']);
+        $this->assertFalse($params['httponly']);
+        $this->assertEquals('Lax', $params['samesite']);
+    }
+}


### PR DESCRIPTION
🎯 **What:** 
Added a missing PHPUnit test file (`tests/apps/inc/SessionTest.php`) for the `apps/inc/session.php` script to verify proper session configuration behavior.

📊 **Coverage:**
* Validates session creation and parameter configuration over a standard HTTP connection.
* Validates session creation and parameter configuration (specifically the `secure` flag) over an HTTPS connection.
* Validates that the script correctly skips configuration and initialization when a session has already been started elsewhere, preventing unwanted state overwrites.

✨ **Result:**
The `session.php` file is now fully tested, preventing potential regressions during future refactoring that could inadvertently weaken session security settings (e.g. `samesite`, `httponly`). The tests run isolated via `@runInSeparateProcess` to prevent state leakage and "headers already sent" errors.

---
*PR created automatically by Jules for task [5006516454766451038](https://jules.google.com/task/5006516454766451038) started by @cahyadsn*