### PR TITLE
🧪 Add tests for fallbackPathForCode in geo_helpers.php

### DIFF
--- a/tests/inc/GeoHelpersTest.php
+++ b/tests/inc/GeoHelpersTest.php
@@ -53,4 +53,40 @@ class GeoHelpersTest extends TestCase {
         $expected = '[[500.5,1500.5],[1500.5,1500.5],[1500.5,2500.5],[500.5,2500.5]]';
         $this->assertEquals($expected, fallbackBox($lat, $lng, $delta));
     }
+
+    public function testFallbackPathForCodeLength13() {
+        $lat = -6.2;
+        $lng = 106.8;
+        $kode = '1234567890123'; // 13 characters
+        $delta = 0.004;
+        $expected = fallbackBox($lat, $lng, $delta);
+        $this->assertEquals($expected, fallbackPathForCode($lat, $lng, $kode));
+    }
+
+    public function testFallbackPathForCodeLength8() {
+        $lat = -6.2;
+        $lng = 106.8;
+        $kode = '12345678'; // 8 characters
+        $delta = 0.008;
+        $expected = fallbackBox($lat, $lng, $delta);
+        $this->assertEquals($expected, fallbackPathForCode($lat, $lng, $kode));
+    }
+
+    public function testFallbackPathForCodeShort() {
+        $lat = -6.2;
+        $lng = 106.8;
+        $kode = '1234'; // 4 characters (less than 8)
+        $delta = 0.01;
+        $expected = fallbackBox($lat, $lng, $delta);
+        $this->assertEquals($expected, fallbackPathForCode($lat, $lng, $kode));
+    }
+
+    public function testFallbackPathForCodeEmpty() {
+        $lat = -6.2;
+        $lng = 106.8;
+        $kode = ''; // 0 characters
+        $delta = 0.01;
+        $expected = fallbackBox($lat, $lng, $delta);
+        $this->assertEquals($expected, fallbackPathForCode($lat, $lng, $kode));
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the testing gap in `apps/inc/geo_helpers.php` by adding unit tests for the previously untested `fallbackPathForCode` function.

📊 **Coverage:** What scenarios are now tested
The following scenarios are now tested in `tests/inc/GeoHelpersTest.php`:
- A code length of 13+ characters (expecting delta = 0.004)
- A code length of 8-12 characters (expecting delta = 0.008)
- A code length < 8 characters (expecting delta = 0.01)
- An empty code string (expecting delta = 0.01)

✨ **Result:** The improvement in test coverage
The `fallbackPathForCode` logic is now robustly tested, verifying its behavior and output across all expected code length thresholds without causing any regression.

---
*PR created automatically by Jules for task [10283125945326009612](https://jules.google.com/task/10283125945326009612) started by @cahyadsn*