### PR TITLE
🔒 fix: Add type validation for id parameter in geo_update endpoint

### DIFF
--- a/apps/inc/geo_update.php
+++ b/apps/inc/geo_update.php
@@ -38,7 +38,7 @@ if (empty($_POST['csrf_token']) || empty($_SESSION['csrf_token']) || !is_string(
 require_once "db.php";
 $r=array('status'=>false,'msg'=>'do nothing');
 $fields=array('lat','lng','path');
-if(isset($_POST['id'])){
+if(isset($_POST['id']) && is_string($_POST['id'])){
   $sql="UPDATE {$tbl_wilayah} SET ";
   $field=$data=array();
   foreach($fields as $f){

--- a/tests/apps/inc/GeoUpdateTest.php
+++ b/tests/apps/inc/GeoUpdateTest.php
@@ -120,6 +120,35 @@ PHP;
         $this->assertEquals('unauthorized', $decoded['msg']);
     }
 
+    public function testIdIsArray()
+    {
+        // Provide an array instead of a string
+        $_POST['id'] = ['1234'];
+
+        putenv('DB_HOST=127.0.0.1');
+
+        $originalErrorLog = ini_get('error_log');
+        ini_set('error_log', strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' ? 'NUL' : '/dev/null');
+        ob_start();
+        @require_once $this->dbFile;
+        ob_end_clean();
+        ini_set('error_log', $originalErrorLog);
+
+        ob_start();
+        $cwd = getcwd();
+        chdir(dirname($this->geoUpdateFile));
+
+        @include basename($this->geoUpdateFile);
+
+        chdir($cwd);
+        $output = ob_get_clean();
+
+        $this->assertJson($output);
+        $decoded = json_decode($output, true);
+        $this->assertFalse($decoded['status']);
+        $this->assertEquals('do nothing', $decoded['msg']);
+    }
+
     public function testNoIdProvided()
     {
         // Require db.php first so require_once in target script skips it


### PR DESCRIPTION
🎯 **What:** Added string type validation for the `id` POST parameter in `apps/inc/geo_update.php` and an accompanying test in `tests/apps/inc/GeoUpdateTest.php`.

⚠️ **Risk:** Without type validation, an attacker could send an array as the `id` parameter (e.g., `id[]=...`), leading to application errors, unexpected behavior, or a `TypeError` when the value is passed to PDO.

🛡️ **Solution:** Validated that `$_POST['id']` is a string using `is_string()` before using it in the database update logic.

---
*PR created automatically by Jules for task [11277572967235338456](https://jules.google.com/task/11277572967235338456) started by @cahyadsn*