### PR TITLE
🔒 fix: prevent TypeError on $_GET['id'] by adding is_string validation

### DIFF
--- a/index.php
+++ b/index.php
@@ -32,7 +32,7 @@ $wil=array(
 	5=>array(8,'Kecamatan','kec'),
 	8=>array(13,'Kelurahan','kel')
 );
-if (isset($_GET['id']) && !empty($_GET['id'])){
+if (isset($_GET['id']) && is_string($_GET['id']) && !empty($_GET['id'])){
 	$n=strlen($_GET['id']);
 	if (isset($wil[$n])) {
 		$query = $db->prepare("SELECT kode, nama FROM wilayah WHERE kode LIKE :id AND CHAR_LENGTH(kode)=:m ORDER BY nama");


### PR DESCRIPTION
🎯 **What:** Added missing type validation on `$_GET['id']` in `index.php`.
⚠️ **Risk:** If an array is passed via the query parameter (e.g. `?id[]=1`), it is passed to `strlen()` which triggers a fatal `TypeError` in PHP 8+, causing application failure and potentially allowing Denial of Service vectors.
🛡️ **Solution:** Added a strict `is_string()` check to ensure the variable is actually a string before evaluating it with `!empty()` and `strlen()`. The global test suite confirms regressions were avoided.

---
*PR created automatically by Jules for task [15959806038742461993](https://jules.google.com/task/15959806038742461993) started by @cahyadsn*