### PR TITLE
🔒 Fix TypeError on $_POST['color'] via is_string check

### DIFF
--- a/apps/inc/change.color.php
+++ b/apps/inc/change.color.php
@@ -37,7 +37,7 @@ if(isset($_POST) && !empty($_POST)){
         $_SESSION['theme']=$_POST['theme']==='light'?'light':'dark';
     }
     //-- set web color theme
-    if(isset($_POST['color'])){
+    if(isset($_POST['color']) && is_string($_POST['color'])){
         $_SESSION['c']=htmlspecialchars($_POST['color'], ENT_QUOTES, 'UTF-8');
     }
 }

--- a/tests/inc/ChangeColorTest.php
+++ b/tests/inc/ChangeColorTest.php
@@ -12,6 +12,32 @@ class ChangeColorTest extends TestCase
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      */
+    public function testColorIgnoresNonStringInput()
+    {
+        // Simulate a POST request setting 'color' to an array
+        $_POST['color'] = ['blue'];
+        $csrfToken = 'valid_token';
+        $_POST['csrf_token'] = $csrfToken;
+
+        // Ensure session array exists to catch the set
+        if (session_status() === PHP_SESSION_NONE) {
+            $_SESSION = [];
+        }
+        $_SESSION['csrf_token'] = $csrfToken;
+
+        ob_start();
+        $code = file_get_contents($this->targetFile);
+        $code = str_replace("require_once __DIR__ . '/session.php';", '', $code);
+        eval('?>' . $code);
+        ob_get_clean();
+
+        $this->assertArrayNotHasKey('c', $_SESSION, 'Session variable "c" should not be set when POST "color" is an array.');
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
     public function testColorIsSetInSession()
     {
         // Simulate a POST request setting 'color'


### PR DESCRIPTION
🎯 **What:** Fixed a `TypeError` vulnerability in `apps/inc/change.color.php` where passing an array to `$_POST['color']` caused an exception when passed to `htmlspecialchars()`.
⚠️ **Risk:** An attacker could potentially trigger a denial of service (DoS) or application error by sending unexpected payload types (like arrays) to endpoints that process the color parameter, causing fatal TypeErrors.
🛡️ **Solution:** Added an `is_string()` check for `$_POST['color']` to ensure only valid string values are processed and stored in the session. Also added a comprehensive test in `ChangeColorTest.php` to assert that invalid inputs are ignored.

---
*PR created automatically by Jules for task [1273669183435033757](https://jules.google.com/task/1273669183435033757) started by @cahyadsn*