### PR TITLE
🔒 Fix missing type validation on $_GET['id'] in Geo Ajax endpoint

### DIFF
--- a/apps/inc/geo_ajax.php
+++ b/apps/inc/geo_ajax.php
@@ -56,7 +56,7 @@ function isPathReasonable($path, $lat, $lng, $kode) {
 }
 
 $r=array('status'=>false,'error'=>'an error occured');
-if (!empty($_GET['id'])){
+if (!empty($_GET['id']) && is_string($_GET['id'])){
   // Try get from table first (has geo data: lat, lng, path, luas, penduduk)
   $query = $db->prepare("SELECT kode, nama, lat, lng, path, luas, penduduk FROM {$tbl_wilayah} WHERE kode=:id");
   $query->execute(array(':id'=>$_GET['id']));

--- a/tests/apps/inc/GeoAjaxTest.php
+++ b/tests/apps/inc/GeoAjaxTest.php
@@ -206,4 +206,42 @@ class GeoAjaxTest extends TestCase {
         $this->assertFalse($result['status']);
         $this->assertEquals('an error occured', $result['error']);
     }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testGeoAjaxIdIsArray() {
+        // Setup env so db.php doesn't actually connect to real DB but we can intercept it
+        putenv('DB_HOST=127.0.0.1');
+
+        $mockPdo = $this->createMock(\PDO::class);
+
+        // Include db.php first to mock the $db connection it creates
+        $originalErrorLog = ini_get('error_log');
+        ini_set('error_log', strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' ? 'NUL' : '/dev/null');
+        ob_start();
+        @require_once __DIR__ . "/../../../apps/inc/db.php";
+        ob_end_clean();
+        ini_set('error_log', $originalErrorLog);
+
+        global $db, $tbl_wilayah;
+        $db = $mockPdo;
+        $tbl_wilayah = 'wilayah';
+
+        $_GET = ['id' => ['an_array']];
+
+        $script = file_get_contents(__DIR__ . "/../../../apps/inc/geo_ajax.php");
+        $script = preg_replace('/require_once\s+[^;]+;/', '', $script);
+        $script = str_replace('function isPathReasonable(', 'function dummy_isPathReasonable_test_avoid_redeclare_array(', $script);
+
+        ob_start();
+        eval('?>' . $script);
+        $output = ob_get_clean();
+
+        $result = json_decode($output, true);
+        $this->assertIsArray($result, "Expected JSON output to decode to an array");
+        $this->assertFalse($result['status']);
+        $this->assertEquals('an error occured', $result['error']);
+    }
 }


### PR DESCRIPTION
🎯 **What:** Missing type validation on `$_GET['id']` in `apps/inc/geo_ajax.php`.
⚠️ **Risk:** An array payload (e.g., `?id[]=1`) passed to `PDOStatement::execute()` or string functions can cause `TypeError` exceptions in PHP 8+ or lead to unexpected query execution, potentially causing crashes or denial of service on the endpoint.
🛡️ **Solution:** Added `is_string($_GET['id'])` to the existing `!empty()` check so that only valid string inputs proceed to the database query logic. Requests with array payloads now gracefully fall back to the default JSON error response. Added a corresponding PHPUnit test to verify the fix.

---
*PR created automatically by Jules for task [16959408363934180210](https://jules.google.com/task/16959408363934180210) started by @cahyadsn*