### PR TITLE
test: add test coverage for invalid ring coordinates

### DIFF
--- a/apps/inc/reverse_lookup.php
+++ b/apps/inc/reverse_lookup.php
@@ -17,10 +17,15 @@ header('Content-Type: application/json');
 
 function pointInRing($lat, $lng, $ring) {
     $inside = false;
+    if (!is_array($ring)) return false;
     $count = count($ring);
     if ($count < 3) return false;
 
     for ($i = 0, $j = $count - 1; $i < $count; $j = $i++) {
+        if (!is_array($ring[$i]) || !isset($ring[$i][0], $ring[$i][1]) ||
+            !is_array($ring[$j]) || !isset($ring[$j][0], $ring[$j][1])) {
+            return false;
+        }
         $yi = (float) $ring[$i][0];
         $xi = (float) $ring[$i][1];
         $yj = (float) $ring[$j][0];

--- a/tests/apps/inc/ReverseLookupTest.php
+++ b/tests/apps/inc/ReverseLookupTest.php
@@ -127,6 +127,17 @@ class ReverseLookupTest extends TestCase
         $this->assertNull($result);
     }
 
+    public function testInvalidRingCoordinates()
+    {
+        $this->loadReverseLookupFunctions();
+
+        // Test coverage for invalid ring coordinates
+        $this->assertFalse(pointInRing(5, 5, null));
+        $this->assertFalse(pointInRing(5, 5, 'string'));
+        $this->assertFalse(pointInRing(5, 5, [ [0], [1], [2] ]));
+        $this->assertFalse(pointInRing(5, 5, [ ["a", "b"], ["c", "d"], ["e", "f"] ]));
+    }
+
     public function testBuildChainFull()
     {
         $this->loadReverseLookupFunctions();

--- a/tests/inc/ReverseLookupTest.php
+++ b/tests/inc/ReverseLookupTest.php
@@ -316,4 +316,13 @@ class ReverseLookupTest extends TestCase
         $this->assertNull(effectiveCandidatePath($candidateE2));
         $this->assertNull(effectiveCandidatePath($candidateE3));
     }
+
+    public function testInvalidRingCoordinates()
+    {
+        // Add test coverage for invalid ring coordinates
+        $this->assertFalse(pointInRing(5, 5, null));
+        $this->assertFalse(pointInRing(5, 5, 'string'));
+        $this->assertFalse(pointInRing(5, 5, [ [0], [1], [2] ]));
+        $this->assertFalse(pointInRing(5, 5, [ ["a", "b"], ["c", "d"], ["e", "f"] ]));
+    }
 }


### PR DESCRIPTION
Resolves the FIXME for testing invalid ring coordinates. Specifically, fixes `pointInRing` so it checks for proper array and structure, safely returning `false` instead of triggering PHP errors, and introduces dedicated tests for these edge cases in both test files related to `ReverseLookup`.

---
*PR created automatically by Jules for task [2923070534138407177](https://jules.google.com/task/2923070534138407177) started by @cahyadsn*