### PR TITLE
🔒 Fix Login CSRF Vulnerability

### DIFF
--- a/apps/login.php
+++ b/apps/login.php
@@ -16,21 +16,29 @@ if (isset($_GET['logout'])) {
 }
 
 $error = '';
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $username = $_POST['username'] ?? '';
-    $password = $_POST['password'] ?? '';
-
-    // Ensure environment variables are set to allow login
-    $expectedUser = getenv('ADMIN_USER');
-    $expectedPass = getenv('ADMIN_PASS');
-
-    if ($expectedUser && $expectedPass && $username === $expectedUser && is_string($password) && password_verify($password, $expectedPass)) {
-        session_regenerate_id(true);
-        $_SESSION['author'] = 'cahyadsn'; // Value expected by geo_update.php
-        header("Location: index.php");
-        exit;
+    if (empty($_POST['csrf_token']) || empty($_SESSION['csrf_token']) || !is_string($_POST['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])) {
+        $error = 'Invalid CSRF token';
     } else {
-        $error = 'Invalid credentials';
+        $username = $_POST['username'] ?? '';
+        $password = $_POST['password'] ?? '';
+
+        // Ensure environment variables are set to allow login
+        $expectedUser = getenv('ADMIN_USER');
+        $expectedPass = getenv('ADMIN_PASS');
+
+        if ($expectedUser && $expectedPass && $username === $expectedUser && is_string($password) && password_verify($password, $expectedPass)) {
+            session_regenerate_id(true);
+            $_SESSION['author'] = 'cahyadsn'; // Value expected by geo_update.php
+            header("Location: index.php");
+            exit;
+        } else {
+            $error = 'Invalid credentials';
+        }
     }
 }
 ?>
@@ -59,6 +67,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             <div class="error"><?= htmlspecialchars($error) ?></div>
         <?php endif; ?>
         <form method="POST" action="">
+            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($_SESSION['csrf_token'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
             <div class="form-group">
                 <label for="username">Username</label>
                 <input type="text" id="username" name="username" required>

--- a/tests/AppsLoginTest.php
+++ b/tests/AppsLoginTest.php
@@ -8,6 +8,14 @@ class AppsLoginTest extends TestCase
 {
     private $loginFile = __DIR__ . '/../apps/login.php';
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+    }
+
     /**
      * Helper to run login.php and return output
      */
@@ -16,7 +24,7 @@ class AppsLoginTest extends TestCase
         ob_start();
         $code = file_get_contents($this->loginFile);
         $code = str_replace('header(', '@header(', $code);
-        $code = str_replace("require_once __DIR__ . '/inc/session.php';", 'session_start();', $code);
+        $code = str_replace("require_once __DIR__ . '/inc/session.php';", 'if (session_status() === PHP_SESSION_NONE) { session_start(); }', $code);
         $code = str_replace('exit;', 'echo "EXIT_CALLED"; return;', $code);
         eval('?>' . $code);
         return ob_get_clean();
@@ -46,6 +54,8 @@ class AppsLoginTest extends TestCase
     public function testLoginSuccessSetsSessionAndRedirects()
     {
         $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_SESSION['csrf_token'] = 'test_csrf_token';
+        $_POST['csrf_token'] = 'test_csrf_token';
         $_POST['username'] = 'admin';
         $_POST['password'] = 'secret';
 
@@ -68,6 +78,8 @@ class AppsLoginTest extends TestCase
     public function testLoginFailureWithWrongCredentials()
     {
         $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_SESSION['csrf_token'] = 'test_csrf_token';
+        $_POST['csrf_token'] = 'test_csrf_token';
         $_POST['username'] = 'admin';
         $_POST['password'] = 'wrong_secret';
 
@@ -91,6 +103,8 @@ class AppsLoginTest extends TestCase
     public function testLoginFailureWithMissingEnvVars()
     {
         $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_SESSION['csrf_token'] = 'test_csrf_token';
+        $_POST['csrf_token'] = 'test_csrf_token';
         $_POST['username'] = 'admin';
         $_POST['password'] = 'secret';
 
@@ -103,6 +117,31 @@ class AppsLoginTest extends TestCase
         $this->assertArrayNotHasKey('author', $_SESSION ?? []);
         $this->assertStringNotContainsString('EXIT_CALLED', $output);
         $this->assertStringContainsString('Invalid credentials', $output);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testLoginFailureWithInvalidCsrfToken()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_SESSION['csrf_token'] = 'test_csrf_token';
+        $_POST['csrf_token'] = 'invalid_csrf_token';
+        $_POST['username'] = 'admin';
+        $_POST['password'] = 'secret';
+
+        putenv('ADMIN_USER=admin');
+        putenv('ADMIN_PASS=' . password_hash('secret', PASSWORD_DEFAULT));
+
+        $output = $this->runLoginScript();
+
+        // Session should not have author
+        $this->assertArrayNotHasKey('author', $_SESSION ?? []);
+        // Should not exit
+        $this->assertStringNotContainsString('EXIT_CALLED', $output);
+        // Should show CSRF error message
+        $this->assertStringContainsString('Invalid CSRF token', $output);
     }
 
     /**


### PR DESCRIPTION
🎯 **What:** The login form in `apps/login.php` did not include a CSRF token, making it susceptible to Login CSRF attacks.

⚠️ **Risk:** An attacker could forge a login request and trick a victim into authenticating as the attacker's account on the site. This could be used for account takeover (if they can later steal the session), tracking the user's activity, or exploiting features that require an authenticated session but use the attacker's context. 

🛡️ **Solution:** Added a hidden `csrf_token` input field to the login form, generated a cryptographically secure token using `bin2hex(random_bytes(32))` which is stored in the session, and explicitly validated the token upon form submission via `POST` using `hash_equals()`. Existing unit tests were updated, and a new test was added to verify validation logic.

---
*PR created automatically by Jules for task [884981594650248716](https://jules.google.com/task/884981594650248716) started by @cahyadsn*