### PR TITLE
🧪 Add test coverage for invalid coords in isPathNearCentroid

### DIFF
--- a/tests/inc/GeoUtilsTest.php
+++ b/tests/inc/GeoUtilsTest.php
@@ -70,4 +70,23 @@ class GeoUtilsTest extends TestCase {
         $this->assertTrue(isPathNearCentroid($path, 5.0, 5.0, '12'));
         $this->assertTrue(isPathNearCentroid($path, 7.5, 7.5, '12'));
     }
+
+    public function testInvalidCoordsInPoints() {
+        // Path containing invalid coordinate entries mixed with valid ones
+        // valid points: [0,0], [0,10], [10,10], [10,0]
+        // latMin = 0, latMax = 10 -> centerLat = 5
+        // lngMin = 0, lngMax = 10 -> centerLng = 5
+        $path = '[[0,0], "invalid_string", [5], [0,10], null, [10,10], [10,0]]';
+
+        // The invalid points should be skipped, and the bounding box should still be calculated correctly
+        $this->assertTrue(isPathNearCentroid($path, 5.0, 5.0, '12'));
+        $this->assertTrue(isPathNearCentroid($path, 7.5, 7.5, '12'));
+        $this->assertFalse(isPathNearCentroid($path, 100.0, 100.0, '12'));
+
+        // Path where the first element is not an array, causing $points to be empty
+        $this->assertFalse(isPathNearCentroid('["invalid"]', 5.0, 5.0, '12'));
+
+        // Path with missing inner arrays
+        $this->assertFalse(isPathNearCentroid('[null]', 5.0, 5.0, '12'));
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of test coverage for valid path arrays containing invalid inner coordinate point structures within `isPathNearCentroid` in `geo_utils.php`.

📊 **Coverage:** The scenarios now tested include a path array mixing valid and invalid entries, ensuring that bad entries are safely skipped and bounding boxes are correctly computed from the valid entries. We also test paths missing inner arrays completely and initial paths containing only invalidly structured inner items.

✨ **Result:** Test coverage for `geo_utils.php` has improved, specifically confirming edge cases around data structure malformation loop skips, ensuring `isPathNearCentroid` correctly filters bad inner points during computation.

---
*PR created automatically by Jules for task [10748333722878686357](https://jules.google.com/task/10748333722878686357) started by @cahyadsn*