### PR TITLE
🧪 Test edge case for invalid string coordinates in pointInRing

### DIFF
--- a/tests/apps/inc/ReverseLookupTest.php
+++ b/tests/apps/inc/ReverseLookupTest.php
@@ -136,6 +136,7 @@ class ReverseLookupTest extends TestCase
         $this->assertFalse(pointInRing(5, 5, 'string'));
         $this->assertFalse(pointInRing(5, 5, [ [0], [1], [2] ]));
         $this->assertFalse(pointInRing(5, 5, [ ["a", "b"], ["c", "d"], ["e", "f"] ]));
+        $this->assertFalse(pointInRing(5, 5, ['invalid', 'invalid', 'invalid']));
     }
 
     public function testBuildChainFull()


### PR DESCRIPTION
🎯 **What:** The `pointInRing` function in `apps/inc/reverse_lookup.php` lacked test coverage for the scenario where the elements of the ring array were plain strings instead of valid coordinate arrays.
📊 **Coverage:** Added a test case in `ReverseLookupTest::testInvalidRingCoordinates` to assert that `pointInRing` correctly returns false when passed a ring containing strings (e.g. `['invalid', 'invalid', 'invalid']`).
✨ **Result:** Improved test coverage and ensured the graceful handling of invalid coordinate structures is verified by the test suite.

---
*PR created automatically by Jules for task [13872343428396939840](https://jules.google.com/task/13872343428396939840) started by @cahyadsn*