### PR TITLE
🧹 [Code Health] Extract shared logic for province HTML generation

### DIFF
--- a/apps/inc/geo_helpers.php
+++ b/apps/inc/geo_helpers.php
@@ -21,3 +21,22 @@ function fallbackPathForCode($lat, $lng, $kode) {
     $delta = ($codeLen >= 13 ? 0.004 : ($codeLen >= 8 ? 0.008 : 0.01));
     return fallbackBox($lat, $lng, $delta);
 }
+
+function getProvinceOptionsHTML($db, $tbl_wilayah, $cache_file) {
+    $cache_ttl = 86400;
+    if (file_exists($cache_file) && (time() - filemtime($cache_file) < $cache_ttl)) {
+        return file_get_contents($cache_file);
+    }
+
+    $query = $db->prepare("SELECT kode,nama FROM {$tbl_wilayah} WHERE CHAR_LENGTH(kode)=2 ORDER BY nama");
+    $query->execute();
+    $arr = [];
+    while ($data = $query->fetchObject()) {
+        $kode = htmlspecialchars($data->kode, ENT_QUOTES, 'UTF-8');
+        $nama = htmlspecialchars($data->nama, ENT_QUOTES, 'UTF-8');
+        $arr[] = '<option value="' . $kode . '">' . $nama . '</option>';
+    }
+    $html = implode('', $arr);
+    file_put_contents($cache_file, $html, LOCK_EX);
+    return $html;
+}

--- a/apps/index.php
+++ b/apps/index.php
@@ -20,6 +20,7 @@ if (empty($_SESSION['csrf_token'])) {
 $theme = $_SESSION['theme'] ?? $_GET['theme'] ?? 'light';
 define("_AUTHOR","cahyadsn");
 require_once 'inc/db.php';
+require_once 'inc/geo_helpers.php';
 $version='3.0.1';
 header('Expires: '.gmdate('D, d M Y H:i:s \G\M\T', time() + 86400));
 header('Cache-Control: public, max-age=86400');
@@ -129,26 +130,7 @@ header('Pragma: cache');
                   <label for="prop">Provinsi</label>
                   <select name="prop" id="prop" class="form-select" onchange="ajax(this.value)">
                     <option value="">Pilih Provinsi</option>
-                    <?php
-                    $cache_file = __DIR__ . '/cache/provinsi_cache.html';
-                    $cache_ttl = 86400;
-
-                    if (file_exists($cache_file) && (time() - filemtime($cache_file) < $cache_ttl)) {
-                      echo file_get_contents($cache_file);
-                    } else {
-                      $query=$db->prepare("SELECT kode,nama FROM {$tbl_wilayah} WHERE CHAR_LENGTH(kode)=2 ORDER BY nama");
-                      $query->execute();
-                      $arr = [];
-                      while ($data=$query->fetchObject()){
-                        $kode = htmlspecialchars($data->kode, ENT_QUOTES, 'UTF-8');
-                        $nama = htmlspecialchars($data->nama, ENT_QUOTES, 'UTF-8');
-                        $arr[] = '<option value="'.$kode.'">'.$nama.'</option>';
-                      }
-                      $html = implode('', $arr);
-                      file_put_contents($cache_file, $html, LOCK_EX);
-                      echo $html;
-                    }
-                    ?>
+                    <?php echo getProvinceOptionsHTML($db, $tbl_wilayah, __DIR__ . '/cache/provinsi_cache.html'); ?>
                   </select>
                 </div>
               </div>

--- a/index.php
+++ b/index.php
@@ -27,6 +27,7 @@ copyright (c) 2017-2022 by cahya dsn; cahyadsn@gmail.com
 ================================================================================*/
 //--- Database configuration
 require_once 'apps/inc/db.php';
+require_once 'apps/inc/geo_helpers.php';
 $wil=array(
 	2=>array(5,'Kota/Kabupaten','kab'),
 	5=>array(8,'Kecamatan','kec'),
@@ -112,26 +113,7 @@ if (isset($_GET['id']) && is_string($_GET['id']) && !empty($_GET['id'])){
 			<td>
 				<select id="prov" onchange="ajax(this.value)">
 					<option value="">Provinsi</option>
-					<?php 
-					$cache_file = __DIR__ . '/cache/provinsi_cache.html';
-					$cache_ttl = 86400;
-
-					if (file_exists($cache_file) && (time() - filemtime($cache_file) < $cache_ttl)) {
-						echo file_get_contents($cache_file);
-					} else {
-						$query=$db->prepare("SELECT kode,nama FROM wilayah WHERE CHAR_LENGTH(kode)=2 ORDER BY nama");
-						$query->execute();
-						$arr = [];
-						while ($data=$query->fetchObject()){
-							$kode = htmlspecialchars($data->kode, ENT_QUOTES, 'UTF-8');
-							$nama = htmlspecialchars($data->nama, ENT_QUOTES, 'UTF-8');
-							$arr[] = '<option value="'.$kode.'">'.$nama.'</option>';
-						}
-						$html = implode('', $arr);
-						file_put_contents($cache_file, $html, LOCK_EX);
-						echo $html;
-					}
-					?>
+						<?php echo getProvinceOptionsHTML($db, "wilayah", __DIR__ . "/cache/provinsi_cache.html"); ?>
 				</select>
 			</td>
 		</tr>

--- a/tests/AppsIndexTest.php
+++ b/tests/AppsIndexTest.php
@@ -54,8 +54,8 @@ class AppsIndexTest extends TestCase
 
         // Modify cache_file path so it writes to the system temp dir during tests
         $code = str_replace(
-            "\$cache_file = __DIR__ . '/cache/provinsi_cache.html';",
-            "\$cache_file = sys_get_temp_dir() . '/provinsi_cache_' . md5(uniqid()) . '.html';",
+            "__DIR__ . '/cache/provinsi_cache.html'",
+            "sys_get_temp_dir() . '/provinsi_cache_' . md5(uniqid()) . '.html'",
             $code
         );
 

--- a/tests/apps/index_php_test.php
+++ b/tests/apps/index_php_test.php
@@ -167,7 +167,7 @@ class IndexPhpTest extends TestCase
      */
     public function testProvinceDropdownQuery(): void
     {
-        $content = file_get_contents(__DIR__ . '/../../apps/index.php');
+        $content = file_get_contents(__DIR__ . '/../../apps/inc/geo_helpers.php');
 
         $this->assertStringContainsString('CHAR_LENGTH(kode)=2', $content,
             'Query must filter for 2-digit province codes');
@@ -286,7 +286,7 @@ class IndexPhpTest extends TestCase
      */
     public function testDatabaseQueryPattern(): void
     {
-        $content = file_get_contents(__DIR__ . '/../../apps/index.php');
+        $content = file_get_contents(__DIR__ . '/../../apps/inc/geo_helpers.php');
 
         // Check for PDO prepared statements
         $this->assertStringContainsString('$db->prepare', $content,


### PR DESCRIPTION
🎯 **What:** The duplicated logic for querying, caching, and generating the province `<option>` HTML tags in `apps/index.php` and `index.php` has been extracted into a single helper function `getProvinceOptionsHTML` inside `apps/inc/geo_helpers.php`.
💡 **Why:** This improves maintainability by centralizing the view logic, removing code duplication, and simplifying both entry scripts. Changes to the query or caching mechanism only need to happen in one place now.
✅ **Verification:** Ran the full PHPUnit test suite. Fixed two tests in `tests/apps/index_php_test.php` that were broken because they expected the database query strings inside `apps/index.php`. The tests now correctly scan `apps/inc/geo_helpers.php`.
✨ **Result:** A cleaner view layer and a DRYer codebase.

---
*PR created automatically by Jules for task [12729083150611766832](https://jules.google.com/task/12729083150611766832) started by @cahyadsn*